### PR TITLE
Added a section to the README about projects using this CoC

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ A code of conduct for your open source project.
 Pledge your respect and appreciation for contributions to your open source project. Add `CODE_OF_CONDUCT.md` to the root of the project folder to let people know that your project is open and welcoming to all contributors.
 
 Please feel free to submit pull requests or open issues to improve the language of this pledge.
+
+## Projects Using the Contributor Covenant
+
+* [AngularJS](https://github.com/angular/code-of-conduct)


### PR DESCRIPTION
We decided to use the Contributor Covenant CoC for Angular. :confetti_ball: This PR adds a short section to the README regarding projects using this CoC.

Because we have so many repos, I think the most pragmatic way to manage the CoC is to [maintain a fork here on the Angular org](https://github.com/angular/code-of-conduct) and link to `CODE_OF_CONDUCT.md` from the `README.md` of each project. In my fork, I edited the `README.md` to explain how the CoC document fits in with the rest of our contributing documentation, but included [attribution for this project](https://github.com/angular/code-of-conduct#credits) (please let me know if there's a better way for me to credit you).

Thanks! :)
