### PR TITLE
Add chef-rvm project to list of projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Please feel free to submit pull requests or open issues to improve the language 
 * [Growing Devs](https://github.com/growingdevs/growingdevs.github.io)
 * [HaskellNow.org Chat](http://www.haskellnow.org/Chat)
 * [Mozilla Webmaker](https://www.webmaker.org/)
+* [chef-rvm](https://github.com/fnichol/chef-rvm)
 
 ## See Also
 


### PR DESCRIPTION
A few weeks ago the [chef-rvm](https://github.com/fnichol/chef-rvm) project officially adopted the code of conduct into master for all future releases.
