### PR TITLE
Clarify language surrounding "representing"

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -8,7 +8,9 @@ Examples of unacceptable behavior by participants include the use of sexual lang
 
 Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
 
-This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.  An individual is deemed to be representing the project or its community if discussing topics germane to the project, or when the individual has explicitly identified as belonging to the project or community in the course of the conversation.
+
+This code of conduct does not apply to opinions expressed in public fora when not representing the project or its community.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -10,7 +10,7 @@ Project maintainers have the right and responsibility to remove, edit, or reject
 
 This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.  An individual is deemed to be representing the project or its community if discussing topics germane to the project, or when the individual has explicitly identified as belonging to the project or community in the course of the conversation.
 
-This code of conduct does not apply to opinions expressed in public fora when not representing the project or its community.
+This code of conduct does not apply to opinions expressed in public while the individual is not representing the project or its community.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
 


### PR DESCRIPTION
Introduces text to clarify the definition of 'representing the project
or its community' to avoid a chilling effect on personal speech while
participating in projects governed by this covenant.

Should this commit be merged, some examples of the sort of situations
that would not constitute 'representing the project or its community'
include:
- Comments made on Twitter, outside the course of a conversation on the
  project itself, where that Twitter profile makes mention of
  participation in the project.
- Comments made on LinkedIn, outside the course of a conversation on
  the project itself, where that LinkedIn profile includes
  participation in the project.
- Comments made on GitHub on projects other than the project covered by
  the Contributor Covenant, except where the author claims membership in
  the project as part of the conversation.
