### PR TITLE
Change "other's" to plural possessive

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -16,7 +16,7 @@ Examples of unacceptable behavior by participants include:
 * Personal attacks  
 * Trolling or insulting/derogatory comments  
 * Public or private harassment  
-* Publishing other's private information, such as physical or electronic  
+* Publishing others' private information, such as physical or electronic  
   addresses, without explicit permission  
 * Other unethical or unprofessional conduct  
 

--- a/version/1/3/0/code_of_conduct.md
+++ b/version/1/3/0/code_of_conduct.md
@@ -16,7 +16,7 @@ Examples of unacceptable behavior by participants include:
 * Personal attacks
 * Trolling or insulting/derogatory comments
 * Public or private harassment
-* Publishing other's private information, such as physical or electronic
+* Publishing others' private information, such as physical or electronic
   addresses, without explicit permission
 * Other unethical or unprofessional conduct
 

--- a/version/1/3/0/code_of_conduct.txt
+++ b/version/1/3/0/code_of_conduct.txt
@@ -18,7 +18,7 @@ Examples of unacceptable behavior by participants include:
 * Personal attacks
 * Trolling or insulting/derogatory comments
 * Public or private harassment
-* Publishing other's private information, such as physical or electronic
+* Publishing others' private information, such as physical or electronic
 addresses, without explicit permission
 * Other unethical or unprofessional conduct
 

--- a/version/1/3/0/index.htm
+++ b/version/1/3/0/index.htm
@@ -38,7 +38,7 @@
   <li>Personal attacks</li>
   <li>Trolling or insulting/derogatory comments</li>
   <li>Public or private harassment</li>
-  <li>Publishing other's private information, such as physical or electronic addresses, without explicit permission</li>
+  <li>Publishing others' private information, such as physical or electronic addresses, without explicit permission</li>
   <li>Other unethical or unprofessional conduct</li>
 </ul>
 


### PR DESCRIPTION
Since we're talking about more than one person, potentially.

This could be changed to "another person's" or "other people's" or something or other (a couple suggestions from @jlee-r7 :). Could drop the word altogether.

https://github.com/rapid7/metasploit-framework/pull/6437