### PR TITLE
Enforce alphabetical order to enforce that no one trait has priority

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,9 +6,9 @@ contribute through reporting issues, posting feature requests, updating
 documentation, submitting pull requests or patches, and other activities.
 
 We are committed to making participation in this project a harassment-free  
-experience for everyone, regardless of level of experience, gender, gender  
-identity and expression, sexual orientation, disability, personal appearance,  
-body size, race, ethnicity, age, religion, or nationality.
+experience for everyone, regardless of age, body size, disability,
+ethnicity, gender, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual orientation.
 
 Examples of unacceptable behavior by participants include:
 


### PR DESCRIPTION
I believe that @aspleenic [has a very good point that the current order of the traits may convey importance or priority of one over another](https://bugs.ruby-lang.org/issues/12004#note-193). The easiest way to do away with this is to simply sort by alphabetical.