### PR TITLE
Remove unprofessional & unethical clauses.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,47 +1,46 @@
 # Contributor Code of Conduct
 
-As contributors and maintainers of this project, and in the interest of  
-fostering an open and welcoming community, we pledge to respect all people who  
-contribute through reporting issues, posting feature requests, updating  
+As contributors and maintainers of this project, and in the interest of
+fostering an open and welcoming community, we pledge to respect all people who
+contribute through reporting issues, posting feature requests, updating
 documentation, submitting pull requests or patches, and other activities.
 
-We are committed to making participation in this project a harassment-free  
-experience for everyone, regardless of level of experience, gender, gender  
-identity and expression, sexual orientation, disability, personal appearance,  
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
 body size, race, ethnicity, age, religion, or nationality.
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery  
-* Personal attacks  
-* Trolling or insulting/derogatory comments  
-* Public or private harassment  
-* Publishing other's private information, such as physical or electronic  
-  addresses, without explicit permission  
-* Other unethical or unprofessional conduct  
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic
+  addresses, without explicit permission
 
-Project maintainers have the right and responsibility to remove, edit, or  
-reject comments, commits, code, wiki edits, issues, and other contributions  
-that are not aligned to this Code of Conduct, or to ban temporarily or  
-permanently any contributor for other behaviors that they deem inappropriate,  
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
 threatening, offensive, or harmful.
 
-By adopting this Code of Conduct, project maintainers commit themselves to  
-fairly and consistently applying these principles to every aspect of managing  
-this project. Project maintainers who do not follow or enforce the Code of  
+By adopting this Code of Conduct, project maintainers commit themselves to
+fairly and consistently applying these principles to every aspect of managing
+this project. Project maintainers who do not follow or enforce the Code of
 Conduct may be permanently removed from the project team.
 
-This code of conduct applies both within project spaces and in public spaces  
+This code of conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be  
-reported by contacting a project maintainer at coraline@idolhands.com. All  
-complaints will be reviewed and investigated and will result in a response that  
-is deemed necessary and appropriate to the circumstances. Maintainers are  
-obligated to maintain confidentiality with regard to the reporter of an  
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting a project maintainer at coraline@idolhands.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. Maintainers are
+obligated to maintain confidentiality with regard to the reporter of an
 incident.
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],  
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 1.3.0, available at
 [http://contributor-covenant.org/version/1/3/0/][version]
 


### PR DESCRIPTION
Please see the rich diff, my editor deleted trailing spaces.

This proposal is to remove the "unprofessional" and "unethical" definitions as they are unnecessarily vague, and cause discomfort to people with autistic spectrum disorders.

Source: https://medium.com/@peterbowyer/an-unintended-side-effect-of-code-of-conducts-e4390c30ab33#.6cujmjti7