### PR TITLE
Convert Markdown versions to semantic linefeeds

### DIFF
--- a/version/1/0/0/code_of_conduct.md
+++ b/version/1/0/0/code_of_conduct.md
@@ -1,13 +1,52 @@
 # Contributor Code of Conduct
 
-As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+As contributors and maintainers of this project,
+we pledge to respect all people who contribute through reporting issues,
+posting feature requests,
+updating documentation,
+submitting pull requests or patches,
+and other activities.
 
-We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+We are committed to making participation in this project
+a harassment-free experience for everyone,
+regardless of level of experience,
+gender,
+gender identity and expression,
+sexual orientation,
+disability,
+personal appearance,
+body size,
+race,
+ethnicity,
+age,
+or religion.
 
-Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+Examples of unacceptable behavior by participants include
+the use of sexual language or imagery,
+derogatory comments or personal attacks,
+trolling,
+public or private harassment,
+insults,
+or other unprofessional conduct.
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
+Project maintainers have the right and responsibility to remove,
+edit,
+or reject comments,
+commits,
+code,
+wiki edits,
+issues,
+and other contributions that are not aligned to this Code of Conduct.
+Project maintainers who do not follow the Code of Conduct
+may be removed from the project team.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+Instances of abusive,
+harassing,
+or otherwise unacceptable behavior may be reported by opening an issue
+or contacting one or more of the project maintainers.
 
-This Code of Conduct is adapted from the [Contributor Covenant](http:contributor-covenant.org), version 1.0.0, available at [http://contributor-covenant.org/version/1/0/0/](http://contributor-covenant.org/version/1/0/0/)
+This Code of Conduct is adapted from the
+[Contributor Covenant](http:contributor-covenant.org),
+version 1.0.0,
+available at
+[http://contributor-covenant.org/version/1/0/0/](http://contributor-covenant.org/version/1/0/0/)

--- a/version/1/1/0/code_of_conduct.md
+++ b/version/1/1/0/code_of_conduct.md
@@ -1,15 +1,56 @@
 # Contributor Code of Conduct
 
-As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+As contributors and maintainers of this project,
+we pledge to respect all people who contribute through reporting issues,
+posting feature requests,
+updating documentation,
+submitting pull requests or patches,
+and other activities.
 
-We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+We are committed to making participation in this project
+a harassment-free experience for everyone,
+regardless of level of experience,
+gender,
+gender identity and expression,
+sexual orientation,
+disability,
+personal appearance,
+body size,
+race,
+ethnicity,
+age,
+or religion.
 
-Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+Examples of unacceptable behavior by participants include
+the use of sexual language or imagery,
+derogatory comments or personal attacks,
+trolling,
+public or private harassment,
+insults,
+or other unprofessional conduct.
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
+Project maintainers have the right and responsibility to remove,
+edit,
+or reject comments,
+commits,
+code,
+wiki edits,
+issues,
+and other contributions that are not aligned to this Code of Conduct.
+Project maintainers who do not follow the Code of Conduct
+may be removed from the project team.
 
-This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+This code of conduct applies both within project spaces
+and in public spaces
+when an individual is representing the project or its community.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+Instances of abusive,
+harassing,
+or otherwise unacceptable behavior may be reported by opening an issue
+or contacting one or more of the project maintainers.
 
-This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.1.0, available at [http://contributor-covenant.org/version/1/1/0/](http://contributor-covenant.org/version/1/1/0/)
+This Code of Conduct is adapted from the
+[Contributor Covenant](http://contributor-covenant.org),
+version 1.1.0,
+available at
+[http://contributor-covenant.org/version/1/1/0/](http://contributor-covenant.org/version/1/1/0/)

--- a/version/1/2/0/code_of_conduct.md
+++ b/version/1/2/0/code_of_conduct.md
@@ -1,8 +1,28 @@
 # Contributor Code of Conduct
 
-As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+As contributors and maintainers of this project,
+and in the interest of fostering an open and welcoming community,
+we pledge to respect all people who contribute through
+reporting issues,
+posting feature requests,
+updating documentation,
+submitting pull requests or patches,
+and other activities.
 
-We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+We are committed to making participation in this project
+a harassment-free experience for everyone,
+regardless of level of experience,
+gender,
+gender identity and expression,
+sexual orientation,
+disability,
+personal appearance,
+body size,
+race,
+ethnicity,
+age,
+religion,
+or nationality.
 
 Examples of unacceptable behavior by participants include:
 
@@ -10,13 +30,35 @@ Examples of unacceptable behavior by participants include:
 * Personal attacks
 * Trolling or insulting/derogatory comments
 * Public or private harassment
-* Publishing other's private information, such as physical or electronic addresses, without explicit permission
+* Publishing other's private information,
+such as physical or electronic addresses,
+without explicit permission
 * Other unethical or unprofessional conduct
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. By adopting this Code of Conduct, project maintainers commit themselves to fairly and consistently applying these principles to every aspect of managing this project. Project maintainers who do not follow or enforce the Code of Conduct may be permanently removed from the project team.
+Project maintainers have the right and responsibility to remove,
+edit,
+or reject comments,
+commits,
+code,
+wiki edits,
+issues,
+and other contributions that are not aligned to this Code of Conduct.
+By adopting this Code of Conduct,
+project maintainers commit themselves to fairly
+and consistently applying these principles to every aspect of managing this project.
+Project maintainers who do not follow
+or enforce the Code of Conduct may be permanently removed from the project team.
 
-This code of conduct applies both within project spaces and in public spaces when an individual is representing the project or its community.
+This code of conduct applies both within project spaces
+and in public spaces when an individual is representing the project or its community.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+Instances of abusive,
+harassing,
+or otherwise unacceptable behavior may be reported by opening an issue
+or contacting one or more of the project maintainers.
 
-This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.2.0, available at [http://contributor-covenant.org/version/1/2/0/](http://contributor-covenant.org/version/1/2/0/)
+This Code of Conduct is adapted from the
+[Contributor Covenant](http://contributor-covenant.org),
+version 1.2.0,
+available at
+[http://contributor-covenant.org/version/1/2/0/](http://contributor-covenant.org/version/1/2/0/)

--- a/version/1/3/0/code_of_conduct.md
+++ b/version/1/3/0/code_of_conduct.md
@@ -1,14 +1,29 @@
 # Contributor Code of Conduct
 
-As contributors and maintainers of this project, and in the interest of
-fostering an open and welcoming community, we pledge to respect all people who
-contribute through reporting issues, posting feature requests, updating
-documentation, submitting pull requests or patches, and other activities.
+As contributors and maintainers of this project,
+and in the interest of fostering an open and welcoming community,
+we pledge to respect all people who contribute through
+reporting issues,
+posting feature requests,
+updating documentation,
+submitting pull requests or patches,
+and other activities.
 
-We are committed to making participation in this project a harassment-free
-experience for everyone, regardless of level of experience, gender, gender
-identity and expression, sexual orientation, disability, personal appearance,
-body size, race, ethnicity, age, religion, or nationality.
+We are committed to making participation in this project
+a harassment-free experience for everyone,
+regardless of level of experience,
+gender,
+gender
+identity and expression,
+sexual orientation,
+disability,
+personal appearance,
+body size,
+race,
+ethnicity,
+age,
+religion,
+or nationality.
 
 Examples of unacceptable behavior by participants include:
 
@@ -16,35 +31,55 @@ Examples of unacceptable behavior by participants include:
 * Personal attacks
 * Trolling or insulting/derogatory comments
 * Public or private harassment
-* Publishing other's private information, such as physical or electronic
-  addresses, without explicit permission
+* Publishing other's private information,
+  such as physical or electronic addresses,
+  without explicit permission
 * Other unethical or unprofessional conduct
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Project maintainers have the right and responsibility to remove,
+edit,
+or
+reject comments,
+commits,
+code,
+wiki edits,
+issues,
+and other contributions
+that are not aligned to this Code of Conduct,
+or to ban temporarily
+or permanently any contributor for other behaviors that they deem inappropriate,
+threatening,
+offensive,
+or harmful.
 
-By adopting this Code of Conduct, project maintainers commit themselves to
-fairly and consistently applying these principles to every aspect of managing
-this project. Project maintainers who do not follow or enforce the Code of
-Conduct may be permanently removed from the project team.
+By adopting this Code of Conduct,
+project maintainers commit themselves to
+fairly and consistently applying these principles to every aspect of managing this project.
+Project maintainers who do not follow
+or enforce the Code of Conduct may be permanently removed from the project team.
 
 This Code of Conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting a project maintainer at [INSERT EMAIL ADDRESS]. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. Maintainers are
-obligated to maintain confidentiality with regard to the reporter of an
-incident.
+Instances of abusive,
+harassing,
+or otherwise unacceptable behavior may be
+reported by contacting a project maintainer at
+[INSERT EMAIL ADDRESS].
+All complaints will be reviewed and investigated
+and will result in a response that is deemed necessary
+and appropriate to the circumstances.
+Maintainers are obligated to maintain confidentiality
+with regard to the reporter of an incident.
 
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 1.3.0, available at
+This Code of Conduct is adapted from the
+[Contributor Covenant][homepage],
+version 1.3.0,
+available at
 [http://contributor-covenant.org/version/1/3/0/][version]
 
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/3/0/
+[homepage]:
+http://contributor-covenant.org
+[version]:
+http://contributor-covenant.org/version/1/3/0/


### PR DESCRIPTION
This PR converts the Markdown versions into [semantic linefeeds](http://rhodesmill.org/brandon/2012/one-sentence-per-line/). The benefit here is that it makes diffing two versions of the Covenant much easier, and will make future version easier to `diff` on GitHub too, rather than [having to use screenshots](https://github.com/CoralineAda/contributor_covenant/pull/226).

I had the idea for this PR, and started doing it manually but paused to [create a tool](https://github.com/cllns/semantic_linefeeds) to help out :) This helped me take care of the punctuation breaks, then I just did some additional breaks on words, on a case-by-case basis (could've made a mistake here)

These things are clearly subjective, other than breaking on punctuation. I generally favored breaking things down as much as I thought reasonable. 

I'm happy to change any particular lines, as it's the overall idea I'm in favor of, rather than this particular patch.

🐹
