### PR TITLE
Add Spring Boot to adopters page

### DIFF
--- a/adopters/index.html
+++ b/adopters/index.html
@@ -109,6 +109,7 @@
 			<li><a href="https://github.com/HugoGiraudel/sass-guidelines">Sass Guidelines</a></li>
 			<li><a href="https://gitlab.com/coraline/snuffle/tree/master">Snuffle</a></li>
 			<li><a href="https://github.com/snipe/snipe-it">Snipe-IT</a></li>
+			<li><a href="https://github.com/spring-projects/spring-boot">Spring Boot</a></li>
 			<li><a href="https://github.com/squirrel/squirrel.windows">Squirrel for Windows</a></li>
 			<li><a href="https://swift.org/community/#code-of-conduct">Swift</a></li>
 			<li><a href="https://github.com/taigaio/code-of-conduct">Taiga.io</a></li>


### PR DESCRIPTION
Thanks for @chelseatroy from Pivotal Labs, we've recently adopted the contributors covenant for Spring Boot.