### PR TITLE
Add note to the top of CODE_OF_CONDUCT.md to reduce confusion

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 **Note: this is the code of conduct for Contributor Covenant itself. To see
-the latest development version of the Contributo Covenant Code of Conduct, see
-[version/latest/code_of_conduct.md](version/latest/code_of_conduct.md).**
+the latest development version of the Contributor Covenant Code of Conduct,
+see [version/latest/code_of_conduct.md](version/latest/code_of_conduct.md).**
 
 # Contributor Code of Conduct
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,7 @@
+**Note: this is the code of conduct for Contributor Covenant itself. To see
+the latest development version of the Contributo Covenant Code of Conduct, see
+[version/latest/code_of_conduct.md](version/latest/code_of_conduct.md).**
+
 # Contributor Code of Conduct
 
 As contributors and maintainers of this project, and in the interest of  


### PR DESCRIPTION
I can't be the only person who has been confused about this. 

Rendered output is at https://github.com/asmeurer/contributor_covenant/blob/confusion/CODE_OF_CONDUCT.md (for proof that the relative link really works). 