### PR TITLE
Fix Japanese version HTML lang attribute

### DIFF
--- a/version/1/3/0/ja/index.htm
+++ b/version/1/3/0/ja/index.htm
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 
-<html lang="jp">
+<html lang="ja">
 <head>
   <meta charset="utf-8"/>
   <title>コントリビュータの行動規範</title>


### PR DESCRIPTION
jp is not a language, use ja or ja-JP instead.

ref.

- https://github.com/ContributorCovenant/contributor_covenant/pull/206#issuecomment-176201056
- https://www.w3.org/TR/html5/dom.html#the-lang-and-xml:lang-attributes
- http://www.ietf.org/rfc/bcp/bcp47.txt