### PR TITLE
Remove passive form in the Enforcement section

### DIFF
--- a/version/latest/code_of_conduct.md
+++ b/version/latest/code_of_conduct.md
@@ -55,10 +55,10 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
+reported by contacting the project team at [INSERT EMAIL ADDRESS]. The project team
+will review and investigate all complaints, and will respond in a way that it deems
+appropriate to the circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident.
 Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good


### PR DESCRIPTION
I propose two changes here:
* Change the passive form to active. The passive form has bureaucratic overtones, and it's ambiguous. Who exactly investigates, and who decides which response is appropriate? In practice, an offender might fight back by claiming that some contributors disagree with the team's response. The offender should have the right to express that opinion, but not the right to appeal the team's decision by exploiting ambiguous wording in the CoC.
* I changed "necessary and appropriate" to just "appropriate". "Necessary" evokes lack of responsibility on the part of the decision-makers.

My personal philosophical bias, which informs the changes above: I'm a bit of an anarchist, and I believe in personal responsibility over formalized enforcement. If I'm a project team member, and I get a report, my response inevitably depends on my personal values and biases. Those values and biases define my community, and if I call myself a community leader, then I have to accept that burden. I am responsibile and in charge. Any language that suggests that I'm just blindly "applying the law" (like the passive form, or the word "necessary"), is an opportunity to evade my duty and revert to bureaucracy, which is the opposite of personal responsibility.

Wow, that was verbose. Sorry. :)