### PR TITLE
Added Android IMSI-Catcher Detector to adopters

### DIFF
--- a/adopters/index.html
+++ b/adopters/index.html
@@ -37,6 +37,7 @@
 
 	<section id="adopters">
 		<ul class="medium-break-two large-break-three">
+			<li><a href="https://github.com/CellularPrivacy/Android-IMSI-Catcher-Detector">Android IMSI-Catcher Detector</a></li>
 			<li><a href="https://github.com/24pullrequests/24pullrequests">24 Pull Requests</a></li>
 			<li><a href="https://github.com/aasm/aasm">AASM</a></li>
 			<li><a href="https://github.com/activeadmin/activeadmin">Active Admin</a></li>


### PR DESCRIPTION
We've been [adopting](https://github.com/CellularPrivacy/Android-IMSI-Catcher-Detector/blob/development/.github/CONTRIBUTING.md#code-of-conduct) your great `Code of Conduct` since quite awhile already and just had [our first case where we had to expell someone](https://github.com/CellularPrivacy/Android-IMSI-Catcher-Detector/issues/832) because of hurting it. Thanks for developing this good guide and mentioning us on your public site so that future contributors of our project know that we stand behind this.