### PR TITLE
Add Vue.js to adopter lists

### DIFF
--- a/adopters/index.html
+++ b/adopters/index.html
@@ -153,7 +153,7 @@
 			<li><a href="https://github.com/adireddy/waud">Waud</a></li>
 			<li><a href="https://github.com/virtapi/">VirtAPI-Stack</a></li>
 			<li><a href="https://github.com/holidays/holidays">Holidays</a></li>
-
+			<li><a href="https://github.com/vuejs/vue">Vue.js</a></li>
 		</ul>
 		<br class="clear">
 		<p>To add your project to the list, submit a pull request <a href="https://github.com/CoralineAda/contributor_covenant" title="Contributor Covenant source code">here</a>.

--- a/index.html
+++ b/index.html
@@ -136,6 +136,7 @@
 			<li><a href="https://github.com/twisted/twisted">Twisted</a></li>
 			<li><a href="https://github.com/Microsoft/visualfsharp">Visual F#</a></li>
 			<li><a href="https://github.com/voltrb/volt">Volt.rb</a></li>
+			<li><a href="https://github.com/vuejs/vue">Vue.js</a></li>
 		</ul>
 		<br class="clear">
 		<p>To add your project to the list, submit a pull request <a href="https://github.com/CoralineAda/contributor_covenant" title="Contributor Covenant source code">here</a>.


### PR DESCRIPTION
I noticed that [Vue.js](https://github.com/vuejs/vue) includes the code of conduct. I added them to both adopter lists seeing as they are a large project.