### PR TITLE
Add Supergiant to list of adopters

### DIFF
--- a/adopters/index.html
+++ b/adopters/index.html
@@ -140,6 +140,7 @@
 			<li><a href="https://github.com/swcarpentry">Software Carpentry</a></li>
 			<li><a href="https://github.com/spring-projects/spring-boot">Spring Boot</a></li>
 			<li><a href="https://github.com/squirrel/squirrel.windows">Squirrel for Windows</a></li>
+			<li><a href="https://supergiant.io/">Supergiant</a></li>
 			<li><a href="https://swift.org/community/#code-of-conduct">Swift</a></li>
 			<li><a href="https://github.com/taigaio/code-of-conduct">Taiga.io</a></li>
 			<li><a href="https://www.tinymce.com/docs/advanced/contributing-to-open-source/">TinyMCE</a></li>


### PR DESCRIPTION
This commit adds [Supergiant](https://supergiant.io/) to the list of adopters.

_Thank you,_ to the contributors who maintain this covenant. We absolutely love the verbiage.

Covenant is included in our documentation, here:
http://supergiant.github.io/docs/community/code-of-conduct.html