### PR TITLE
Add Quack Lang

### DIFF
--- a/adopters/index.html
+++ b/adopters/index.html
@@ -117,6 +117,7 @@
 			<li><a href="https://github.com/praw-dev/praw">PRAW</a></li>
 			<li><a href="https://github.com/graycatlabs/PyBBIO">PyBBIO</a></li>
 			<li><a href="https://github.com/qa-tools/qa-tools">QA-Tools</a></li>
+			<li><a href="https://github.com/quack/quack">Quack Lang</a></li>
 			<li><a href="https://github.com/kickstarter/rack-attack">Rack::Attack</a></li>
 			<li><a href="https://github.com/rails/rails">Rails</a></li>
 			<li><a href="https://github.com/rbenv/rbenv">rbenv</a></li>


### PR DESCRIPTION
This pull-request adds the :baby_chick: [Quack Lang](https://github.com/quack/quack) for the list of projects that use this code of conduct. :rainbow:

Website: [http://quack.github.io/quack/](http://quack.github.io/quack/)