### PR TITLE
Add Pexip to list of adopters

### DIFF
--- a/adopters/index.html
+++ b/adopters/index.html
@@ -111,6 +111,7 @@
 			<li><a href="https://github.com/CenturyLinkLabs/panamax-ui">Panamax</a></li>
 			<li><a href="https://github.com/iancooper/Paramore">Paramore</a></li>
 			<li><a href="https://github.com/Pash-Project/Pash">Pash</a></li>
+			<li><a href="https://github.com/pexip/pexkit-sdk">Pexip - Video Conferencing SDK</a></li>
 			<li><a href="https://github.com/pixijs/pixi-haxe">Pixi.js Haxe Externs</a></li>
 			<li><a href="http://vectorpoem.com/playscii">Playscii</a></li>
 			<li><a href="https://github.com/bruceadams/pmap">pmap</a></li>


### PR DESCRIPTION
Video Conferencing SDK for iOS, Android and Web (via WebRTC) to allow communication
with pexip servers.

See https://www.pexip.com/ and https://github.com/pexip/pexkit-sdk/