### PR TITLE
Add Quick to adopters list.

### DIFF
--- a/adopters/index.html
+++ b/adopters/index.html
@@ -167,6 +167,7 @@
 			<li><a href="https://github.com/virtapi/">VirtAPI-Stack</a></li>
 			<li><a href="https://github.com/holidays/holidays">Holidays</a></li>
 			<li><a href="https://github.com/vuejs/vue">Vue.js</a></li>
+			<li><a href="https://github.com/Quick/Quick">Quick</a></li>
 		</ul>
 		<br class="clear">
 		<p>To add your project to the list, submit a pull request <a href="https://github.com/CoralineAda/contributor_covenant" title="Contributor Covenant source code">here</a>.


### PR DESCRIPTION
The Quick organisation has adopted the Contributor Covenant.

Related to https://github.com/Quick/Quick/pull/574#issuecomment-241153653.

:)