### PR TITLE
Add Swedish translation

### DIFF
--- a/i18n/index.html
+++ b/i18n/index.html
@@ -108,7 +108,12 @@
           <td><a href="/version/1/3/0/ru/">Pусский</a> (1.3)</td>
           <td><a href="/version/1/3/0/ru/code_of_conduct.txt">Pусский</a> (1.3)</td>
         </tr>
-	<tr>
+        <tr>
+          <td><a href="/version/1/4/0/sv/code_of_conduct.md">Svenska</a> (1.4)</td>
+          <td><a href="/version/1/4/0/sv/">Svenska</a> (1.4)</td>
+          <td><a href="/version/1/4/0/sv/code_of_conduct.txt">Svenska</a> (1.4)</td>
+        </tr>
+        <tr>
           <td><a href="/version/1/4/sl/code_of_conduct.md">Slovenščina</a> (1.4)</td>
           <td><a href="/version/1/4/sl/">Slovenščina</a> (1.4)</td>
           <td><a href="/version/1/4/sl/code_of_conduct.txt">Slovenščina</a> (1.4)</td>

--- a/version/1/4/sv/code_of_conduct.md
+++ b/version/1/4/sv/code_of_conduct.md
@@ -1,0 +1,75 @@
+# Medarbetarfördragets Uppförandekod
+
+## Vårt löfte
+
+I syftet att fostra en öppen och välkomnande miljö, avlägger vi i egenskap av
+medarbetare och ansvariga ett löfte att göra deltagande i vårt projekt och
+samfund en upplevelse fri från trakasserier för alla, oavsett ålder,
+kroppsstorlek, handikapp, etnicitet, könsidentitet och könsuttryck,
+erfarenhetsnivå, nationalitet, personligt utseende, ras, religion, eller sexuell
+identitet och läggning.
+
+## Våra standarder
+
+Exempel på uppförande som bidrar till att skapa en positiv miljö inkluderar:
+
+* Användande av välkomnande och inklusivt språk
+* Uppvisande av respekt för olika synpunkter och upplevelser
+* Ödmjukt mottagande av konstruktiv kritik
+* Fokusera på vad som är bäst för samfundet
+* Uppvisande av empati mot andra medlemmar av samfundet
+
+Exempel på oacceptabelt uppförande av deltagare inkluderar:
+
+* Användande av sexualiserat språk eller bildspråk och ovälkommen sexuell
+uppmärksamhet eller närmanden
+* Trollande, förolämpande/nedsättande kommentarer, och personliga eller
+politiska attacker
+* Offentliga eller privata trakasserier
+* Publicerande av andras privata information, såsom en fysisk eller elektronisk
+adress, utan explicit medgivande
+* Annat uppförande som rimligen skulle kunna anses vara olämpligt i en
+professionell miljö
+
+## Våra förpliktelser
+
+Projektansvariga är ansvariga för att klargöra standarderna för acceptabelt
+beteende och förväntas ta lämplig och rättvis korrigerande åtgärd i respons till
+alla instanser av oacceptabelt uppförande.
+
+Projektansvariga har rätten och ansvaret för att avlägsna, redigera, eller
+avvisa kommentarer, förbindelser, kod, wiki-redigeringar, problem, och andra
+bidrag som inte lierar sig med denna Uppförandekod, eller att temporärt eller
+permanent bannlysa en medarbetare för annat beteende som anses opassande,
+hotande, kränkande, eller skadligt.
+
+## Omfattning
+
+Denna Uppförandekod tillämpas både inom projektutrymmen och på allmänna platser
+när en individ representerar projektet och dess samfund. Exempel på att
+representera ett projekt eller samfund inkluderar nyttjande av en officiell
+projektepostaddress, publicerande via ett officiellt konto på sociala medier,
+eller agerande i egenskap av utsedd representant på ett online- eller offline-
+evenemang. Representation av ett projekt kan definieras ytterligare och
+klargöras av projektansvariga.
+
+## Upprätthållande
+
+Fall av kränkande, trakasserande, eller på annat sätt oacceptabelt beteende kan
+rapporteras genom att kontakta projektgruppen på [INFOGA EPOSTADRESS]. Alla
+klagomål kommer att granskas och undersökas och resultera i en respons som anses
+nödvändig och lämplig under omständigheterna. Projektgruppen är skyldig att
+upprätthålla sekretess med avseende på rapportören av en incident. Ytterligare
+information angående specifik upprätthållandepolicy kan postas separat.
+
+Projektansvariga som inte följer eller upprätthåller Uppförandekoden i god tro
+kan ställas inför temporära eller permanenta konsekvenser som bestäms av andra
+medlemmar av projektets ledning.
+
+## Tillskrivning
+
+Denna Uppförandekod är anpassad efter [Contributor Covenant][hemsida],
+version 1.4, tillgänglig på [http://contributor-covenant.org/version/1/4][version]
+
+[hemsida]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/version/1/4/sv/code_of_conduct.txt
+++ b/version/1/4/sv/code_of_conduct.txt
@@ -1,6 +1,6 @@
-# Medarbetarförbundets Uppförandekod
+Medarbetarförbundets Uppförandekod
 
-## Vårt löfte
+Vårt löfte
 
 I syftet att fostra en öppen och välkomnande miljö, avlägger vi i egenskap av
 medarbetare och ansvariga ett löfte att göra deltagande i vårt projekt och
@@ -9,7 +9,7 @@ kroppsstorlek, handikapp, etnicitet, könsidentitet och könsuttryck,
 erfarenhetsnivå, nationalitet, personligt utseende, ras, religion, eller sexuell
 identitet och läggning.
 
-## Våra standarder
+Våra standarder
 
 Exempel på uppförande som bidrar till att skapa en positiv miljö inkluderar:
 
@@ -31,7 +31,7 @@ adress, utan explicit medgivande
 * Annat uppförande som rimligen skulle kunna anses vara olämpligt i en
 professionell miljö
 
-## Våra förpliktelser
+Våra förpliktelser
 
 Projektansvariga är ansvariga för att klargöra standarderna för acceptabelt
 beteende och förväntas ta lämplig och rättvis korrigerande åtgärd i respons till
@@ -43,7 +43,7 @@ bidrag som inte lierar sig med denna Uppförandekod, eller att temporärt eller
 permanent bannlysa en medarbetare för annat beteende som anses opassande,
 hotande, kränkande, eller skadligt.
 
-## Omfattning
+Omfattning
 
 Denna Uppförandekod tillämpas både inom projektutrymmen och på allmänna platser
 när en individ representerar projektet och dess samfund. Exempel på att
@@ -53,7 +53,7 @@ eller agerande i egenskap av utsedd representant på ett online- eller offline-
 evenemang. Representation av ett projekt kan definieras ytterligare och
 klargöras av projektansvariga.
 
-## Upprätthållande
+Upprätthållande
 
 Fall av kränkande, trakasserande, eller på annat sätt oacceptabelt beteende kan
 rapporteras genom att kontakta projektgruppen på [INFOGA EPOSTADRESS]. Alla
@@ -66,10 +66,8 @@ Projektansvariga som inte följer eller upprätthåller Uppförandekoden i god t
 kan ställas inför temporära eller permanenta konsekvenser som bestäms av andra
 medlemmar av projektets ledning.
 
-## Attribuering
+Attribuering
 
-Denna Uppförandekod är anpassad efter [Contributor Covenant][hemsida],
-version 1.4, tillgänglig på [http://contributor-covenant.org/version/1/4][version]
-
-[hemsida]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+Denna Uppförandekod är anpassad efter Contributor Covenant:
+http://contributor-covenant.org, version 1.4, tillgänglig på
+http://contributor-covenant.org/version/1/4

--- a/version/1/4/sv/index.html
+++ b/version/1/4/sv/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+
+<html lang="es">
+<head>
+  <meta charset="utf-8"/>
+  <title>Contributor Covenant 1.4.0</title>
+  <style>
+    body {
+      font-family: monospace;
+      padding: 4em;
+    }
+    a {
+      color: #990000;
+    }
+  </style>
+  <link rel="alternate" hreflang="en" href="version/1/4/" />
+  <link rel="alternate" hreflang="de" href="version/1/3/0/de/" />
+  <link rel="alternate" hreflang="fr" href="version/1/3/0/fr/" />
+  <link rel="alternate" hreflang="hu" href="version/1/3/0/hu/" />
+  <link rel="alternate" hreflang="it" href="version/1/3/0/it/" />
+  <link rel="alternate" hreflang="ja" href="version/1/3/0/ja/" />
+  <link rel="alternate" hreflang="pl" href="version/1/4/pl/" />
+  <link rel="alternate" hreflang="pt" href="version/1/3/0/pt/" />
+  <link rel="alternate" hreflang="pt" href="version/1/3/0/pt_br/" />
+  <link rel="alternate" hreflang="ru" href="version/1/4/ru/" />
+  <link rel="alternate" hreflang="sl" href="version/1/4/sl/" />
+</head>
+<body>
+  <h1>Medarbetarförbundets Uppförandekod</h1>
+
+  <h2>Vårt löfte</h2>
+
+  <p>I syftet att fostra en öppen och välkomnande miljö, avlägger vi i egenskap av
+  medarbetare och ansvariga ett löfte att göra deltagande i vårt projekt och
+  samfund en upplevelse fri från trakasserier för alla, oavsett ålder,
+  kroppsstorlek, handikapp, etnicitet, könsidentitet och könsuttryck,
+  erfarenhetsnivå, nationalitet, personligt utseende, ras, religion, eller sexuell
+  identitet och läggning.</p>
+  
+  <h2>Våra standarder</h2>
+  
+  <p>Exempel på uppförande som bidrar till att skapa en positiv miljö inkluderar:</p>
+  <ul>
+    <li> Användande av välkomnande och inklusivt språk</li>
+    <li> Uppvisande av respekt för olika synpunkter och upplevelser</li>
+    <li> Ödmjukt mottagande av konstruktiv kritik</li>
+    <li> Fokusera på vad som är bäst för samfundet</li>
+    <li> Uppvisande av empati mot andra medlemmar av samfundet</li>
+  </ul>
+  <p>Exempel på oacceptabelt uppförande av deltagare inkluderar:</p>
+  <ul>
+  <li>* Användande av sexualiserat språk eller bildspråk och ovälkommen sexuell</li>
+  <li>uppmärksamhet eller närmanden</li>
+  <li>* Trollande, förolämpande/nedsättande kommentarer, och personliga eller</li>
+  <li>politiska attacker</li>
+  <li>* Offentliga eller privata trakasserier</li>
+  <li>* Publicerande av andras privata information, såsom en fysisk eller elektronisk</li>
+  <li>adress, utan explicit medgivande</li>
+  <li>* Annat uppförande som rimligen skulle kunna anses vara olämpligt i en
+  professionell miljö</li>
+  </ul>
+  
+  <h2>Våra förpliktelser</h2>
+  
+  <p>Projektansvariga är ansvariga för att klargöra standarderna för acceptabelt
+  beteende och förväntas ta lämplig och rättvis korrigerande åtgärd i respons till
+  alla instanser av oacceptabelt uppförande.</p>
+  
+  <p>Projektansvariga har rätten och ansvaret för att avlägsna, redigera, eller
+  avvisa kommentarer, förbindelser, kod, wiki-redigeringar, problem, och andra
+  bidrag som inte lierar sig med denna Uppförandekod, eller att temporärt eller
+  permanent bannlysa en medarbetare för annat beteende som anses opassande,
+  hotande, kränkande, eller skadligt.</p>
+  
+  <h2>Omfattning</h2>
+  
+  <p>Denna Uppförandekod tillämpas både inom projektutrymmen och på allmänna platser
+  när en individ representerar projektet och dess samfund. Exempel på att
+  representera ett projekt eller samfund inkluderar nyttjande av en officiell
+  projektepostaddress, publicerande via ett officiellt konto på sociala medier,
+  eller agerande i egenskap av utsedd representant på ett online- eller offline-
+  evenemang. Representation av ett projekt kan definieras ytterligare och
+  klargöras av projektansvariga.</p>
+  
+  <h2>Upprätthållande</h2>
+  
+  <p>Fall av kränkande, trakasserande, eller på annat sätt oacceptabelt beteende kan
+  rapporteras genom att kontakta projektgruppen på [INFOGA EPOSTADRESS]. Alla
+  klagomål kommer att granskas och undersökas och resultera i en respons som anses
+  nödvändig och lämplig under omständigheterna. Projektgruppen är skyldig att
+  upprätthålla sekretess med avseende på rapportören av en incident. Ytterligare
+  information angående specifik upprätthållandepolicy kan postas separat.</p>
+  
+  <p>Projektansvariga som inte följer eller upprätthåller Uppförandekoden i god tro
+  kan ställas inför temporära eller permanenta konsekvenser som bestäms av andra
+  medlemmar av projektets ledning.</p>
+  
+  <h2>Attribuering</h2>
+  
+  <p>Denna Uppförandekod är anpassad efter [Contributor Covenant][hemsida],
+  version 1.4, tillgänglig på [http://contributor-covenant.org/version/1/4][version]</p>
+  
+  [hemsida]: http://contributor-covenant.org
+  [version]: http://contributor-covenant.org/version/1/4/
+  


### PR DESCRIPTION
It’s stilted in places, as Swedes tend to use a lot of Swenglish in technical contexts, but that looks odd in formal writing. I couldn’t come up with a translation of `Contributor Covenant Code of Conduct` without treating `Contributor Covenant` like a proper noun.