### PR TITLE
Adding the .md extension to the Home broken link

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
 	</section>
 
 	<section id="footer">
-		The Contributor Covenant was created by <a href="http://where.coraline.codes/" title="Coraline Ada Ehmke">Coraline Ada Ehmke</a> in 2014 and is released under an <a href="https://github.com/ContributorCovenant/contributor_covenant/blob/master/LICENSE">MIT license</a>.<br>
+		The Contributor Covenant was created by <a href="http://where.coraline.codes/" title="Coraline Ada Ehmke">Coraline Ada Ehmke</a> in 2014 and is released under an <a href="https://github.com/ContributorCovenant/contributor_covenant/blob/master/LICENSE.md">MIT license</a>.<br>
 		Support this and other diversity initiatives through <a href="https://www.patreon.com/coraline" title="Patreon">our Patreon</a>.
 	</section>
 


### PR DESCRIPTION
Issue:
Site: license link is broken, text is outdated #350