### PR TITLE
Minor update to the HTML5 semantics

### DIFF
--- a/adopters/index.html
+++ b/adopters/index.html
@@ -17,19 +17,19 @@
 </head>
 <body>
 
-	<section id="header">
+	<header id="header">
 		<h1>Contributor Covenant</h1>
-		<h2>A Code of Conduct for Open Source Projects.</h2>
-	</section>
+		<p class="subtitle">A Code of Conduct for Open Source Projects.</p>
+	</header>
 
-	<section id="navigation">
+	<nav id="navigation">
 		<ul>
 			<li><a href="/">Home</a></li>
 			<li><a href="/adopters/">Adopters</a></li>
 			<li><a href="/version/1/4">Latest Version</a></li>
 			<li><a href="/i18n/">Translations</a></li>
 		</ul>
-	</section>
+	</nav>
 
 	<section id="introduction">
 		<h3>A Sample of Projects Adopting the Contributor Covenant</h3>
@@ -184,10 +184,10 @@
 		<p>To add your project to the list, submit a pull request <a href="https://github.com/CoralineAda/contributor_covenant" title="Contributor Covenant source code">here</a>.
 	</section>
 
-	<section id="footer">
+	<footer id="footer">
 		The Contributor Covenant was created by <a href="http://where.coraline.codes/" title="Coraline Ada Ehmke">Coraline Ada Ehmke</a> in 2014 and is released under an <a href="https://github.com/ContributorCovenant/contributor_covenant/blob/master/LICENSE">MIT license</a>.<br>
 		Support this and other diversity initiatives through <a href="https://www.patreon.com/coraline">our Patreon</a>.
-	</section>
+	</footer>
 
 </body>
 </html>

--- a/i18n/index.html
+++ b/i18n/index.html
@@ -17,19 +17,19 @@
 </head>
 <body>
 
-  <section id="header">
+  <header id="header">
     <h1>Contributor Covenant</h1>
-    <h2>A Code of Conduct for Open Source Projects.</h2>
-  </section>
+    <p class="subtitle">A Code of Conduct for Open Source Projects.</p>
+  </header>
 
-  <section id="navigation">
+  <nav id="navigation">
     <ul>
       <li><a href="/">Home</a></li>
       <li><a href="/adopters/">Adopters</a></li>
       <li><a href="/version/1/4">Latest Version</a></li>
       <li><a href="/i18n/">Translations</a></li>
     </ul>
-  </section>
+  </nav>
 
   <section id="localizations">
     <h3>Contributor Covenant Translations</h3>
@@ -148,10 +148,10 @@
     <p>The Contributor Covenant uses semantic versioning for revisions so all URLs are permanent. Previous versions are available here: <a href="/version/1/0/0/">1.0</a>, <a href="/version/1/1/0/">1.1</a>, <a href="/version/1/2/0/">1.2</a>, and <a href="/version/1/3/0/">1.3</a>.</p>
   </section>
 
-  <section id="footer">
+  <footer id="footer">
     The Contributor Covenant was created by <a href="http://where.coraline.codes/" title="Coraline Ada Ehmke">Coraline Ada Ehmke</a> in 2014 and is released under an <a href="https://github.com/ContributorCovenant/contributor_covenant/blob/master/LICENSE">MIT license</a>.<br>
     Support this and other diversity initiatives through <a href="https://www.patreon.com/coraline">our Patreon</a>.
-  </section>
+  </footer>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -17,19 +17,19 @@
 </head>
 <body>
 
-	<section id="header">
+	<header id="header">
 		<h1>Contributor Covenant</h1>
-		<h2 class="subtitle">A Code of Conduct for Open Source Projects.</h2>
-	</section>
+		<p class="subtitle">A Code of Conduct for Open Source Projects.</p>
+	</header>
 
-	<section id="navigation">
+	<nav id="navigation">
 		<ul>
 			<li><a href="/">Home</a></li>
 			<li><a href="/adopters/">Adopters</a></li>
 			<li><a href="/version/1/4">Latest Version</a></li>
 			<li><a href="/i18n/">Translations</a></li>
 		</ul>
-	</section>
+	</nav>
 
 	<section id="preamble">
 		<p>Open Source has always been a foundation of the Internet, and with the advent of social open source networks this is more true than ever. But free, libre, and open source projects suffer from a startling lack of diversity, with dramatically low participation by women, people of color, and other marginalized populations.</p>
@@ -153,10 +153,10 @@
 		<p>The Contributor Covenant is a living document, and has been open sourced. Its repository can be found <a href="https://github.com/CoralineAda/contributor_covenant" title="Contributor Covenant source code">here</a>. Contributions in the form of issues and pull requests are welcomed and encouraged.</p>
 	</section>
 
-	<section id="footer">
+	<footer id="footer">
 		The Contributor Covenant was created by <a href="http://where.coraline.codes/" title="Coraline Ada Ehmke">Coraline Ada Ehmke</a> in 2014 and is released under an <a href="https://github.com/ContributorCovenant/contributor_covenant/blob/master/LICENSE">MIT license</a>.<br>
 		Support this and other diversity initiatives through <a href="https://www.patreon.com/coraline" title="Patreon">our Patreon</a>.
-	</section>
+	</footer>
 
 </body>
 </html>

--- a/styles/main.css
+++ b/styles/main.css
@@ -19,6 +19,8 @@ body {
 	padding: 6rem 0 1.5rem;
 	text-align: center;
 }
+header,
+footer,
 section {
 	margin: 0 auto;
 	max-width: 60rem;
@@ -80,6 +82,9 @@ kbd {
 
 table.localizations td {
 	font-family: courier, monospace;
+}
+.subtitle {
+  font-size: 1.5rem;
 }
 
 /* Media Queries */


### PR DESCRIPTION
Minor changes to the section semantics (for the purpose of sr-readability).

`section` changed to the more sr-compliant elements `header`, `nav`, and `footer`  for the sections performing these roles.  For the non-header subtitle, `h2` has been changed to `p`.

The css has been updated only to keep the styles functionally the same with the new changes.