### PR TITLE
add Vox Pupuli to the list of adopters

### DIFF
--- a/adopters/index.html
+++ b/adopters/index.html
@@ -175,6 +175,7 @@
 			<li><a href="https://github.com/virtapi/">VirtAPI-Stack</a></li>
 			<li><a href="https://github.com/Microsoft/visualfsharp">Visual F#</a></li>
 			<li><a href="https://github.com/voltrb/volt">Volt.rb</a></li>
+			<li><a href="https://voxpupuli.org/">Vox Pupuli</a></li>
 			<li><a href="https://github.com/vuejs/vue">Vue.js</a></li>
 			<li><a href="https://gitlab.com/cpp.cabrera/wai-request-spec">WAI-request-spec</a></li>
 			<li><a href="https://github.com/adireddy/waud">Waud</a></li>


### PR DESCRIPTION
Vox Pupuli is a community that gives a home for Puppet modules and
authors. We're using this CoC since a long long time but somehow forget
to add us to the list of adopters. All of our repos should have include
a copy of the CoC.