### PR TITLE
Add first contributions to adopters list

### DIFF
--- a/adopters/index.html
+++ b/adopters/index.html
@@ -74,6 +74,7 @@
 			<li><a href="https://github.com/electron/electron">Electron</a></li>
 			<li><a href="https://github.com/elixir-lang/elixir">Elixir</a></li>
 			<li><a href="https://github.com/exercism/exercism.io">Exercism.io</a></li>
+			<li><a href="https://github.com/multunus/first-contributions">First Contributions</a></li>
 			<li><a href="https://github.com/freedomotic/freedomotic">Freedomotic</a></li>
 			<li><a href="https://github.com/JacobEvelyn/friends">friends</a></li>
 			<li><a href="https://gitlab.com/coraline/fukuzatsu/tree/master">Fukuzatsu</a></li>


### PR DESCRIPTION
Added a link to [First Contributions](https://github.com/multunus/first-contributions)