### PR TITLE
add margin to the subtitle so it doesn't go right to the edge on mobile

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -14,6 +14,12 @@ body {
 	text-align: center;
 	width: 100%;
 }
+
+#header .subtitle{
+	margin-left: 20px;
+	margin-right: 20px;
+}
+
 #footer {
 	font-size: .8rem;
 	padding: 6rem 0 1.5rem;


### PR DESCRIPTION
I noticed the styling looked a little broken on mobile, so I fixed it.