### PR TITLE
Add GNSS-SDR to the projects list

### DIFF
--- a/adopters/index.html
+++ b/adopters/index.html
@@ -80,6 +80,7 @@
 			<li><a href="https://gitlab.com/coraline/fukuzatsu/tree/master">Fukuzatsu</a></li>
 			<li><a href="https://github.com/git-for-windows">Git for Windows</a></li>
 			<li><a href="https://github.com/gitlabhq/gitlabhq">GitLab</a></li>
+			<li><a href="https://github.com/gnss-sdr/gnss-sdr">GNSS-SDR</a></li>
 			<li><a href="https://github.com/ruby-grape/grape">Grape</a></li>
 			<li><a href="https://github.com/growingdevs/growingdevs.github.io">Growing Devs</a></li>
 			<li><a href="https://github.com/goreleaser/releaser">GoReleaser</a></li>


### PR DESCRIPTION
The CODE_OF_CONDUCT.md file has been included in the root folder of https://github.com/gnss-sdr/gnss-sdr

Also online at http://gnss-sdr.org/code-of-conduct/ and https://github.com/gnss-sdr/geniuss-place/