### PR TITLE
Add Bionode to adopters

### DIFF
--- a/adopters/index.html
+++ b/adopters/index.html
@@ -48,6 +48,7 @@
 			<li><a href="https://github.com/atom/atom">Atom</a></li>
 			<li><a href="https://github.com/babel/babel">Babel</a></li>
 			<li><a href="http://baleen.org">Baleen</a> (<a href="https://github.com/baleen/migrations"> Migrations</a>, <a href="https://github.com/baleen/cli" >CLI</a>)</li>
+			<li><a href="http://bionode.io">Bionode</a></li>
 			<li><a href="http://bridge.net">Bridge.NET</a></li>
 			<li><a href="http://cakebuild.net">Cake</a></li>
 			<li><a href="https://github.com/Automattic/wp-calypso">Calypso (WordPress.com)</a></li>


### PR DESCRIPTION
Thank you for creating a versioned CODE_OF_CONDUCT.md! We started using it in our [main repo](https://github.com/bionode/bionode/blob/master/CODE_OF_CONDUCT.md) but now it's present in [all of them](https://github.com/search?q=org:bionode+type:pr+CODE_OF_CONDUCT.md).
