### PR TITLE
Fix link in FR version

### DIFF
--- a/version/1/4/fr/code_of_conduct.md
+++ b/version/1/4/fr/code_of_conduct.md
@@ -73,5 +73,5 @@ répercussions définies par d'autres membres de la direction du projet.
 
 Ce Code de Conduite est adapté du [Contributor Covenant](http://contributor-covenant.org),
 version 1.4.0, disponible à
-[http://contributor-covenant.org/version/1/4/0/fr](http://contributor-covenant.org/version/1/4/0/fr)
+<http://contributor-covenant.org/version/1/4/fr>
 

--- a/version/1/4/fr/code_of_conduct.txt
+++ b/version/1/4/fr/code_of_conduct.txt
@@ -73,4 +73,4 @@ Attribution
 
 Ce Code de Conduite est adaptée du Contributor Covenant (http://contributor-covenant.org),
 version 1.4.0, disponible à
-http://contributor-covenant.org/version/1/4/0/fr
+http://contributor-covenant.org/version/1/4/fr

--- a/version/1/4/fr/index.html
+++ b/version/1/4/fr/index.html
@@ -93,7 +93,7 @@ répercussions définies par d'autres membres de la direction du projet.</p>
 
 <p>Ce Code de Conduite est adaptée du Contributor Covenant,
 version 1.4.0, disponible à
-<a href="http://contributor-covenant.org/version/1/4/0/fr">http://contributor-covenant.org/version/1/4/0/fr</a></p>
+<a href="http://contributor-covenant.org/version/1/4/fr">http://contributor-covenant.org/version/1/4/fr</a></p>
 
 </body>
 </html>


### PR DESCRIPTION
Remove `/0` from http://contributor-covenant.org/version/1/4/0/fr to http://contributor-covenant.org/version/1/4/fr