### PR TITLE
added sex as a protected characteristic

### DIFF
--- a/version/latest/code_of_conduct.md
+++ b/version/latest/code_of_conduct.md
@@ -4,10 +4,10 @@
 
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, gender identity and expression, level of experience,
-nationality, personal appearance, race, religion, sexual identity and
-orientation, or sexual proclivities between consenting adults.
+our community a harassment-free experience for everyone, regardless of sex, age,
+body size, disability, ethnicity, gender identity and expression,
+level of experience, nationality, personal appearance, race, religion,
+sexual identity and orientation, or sexual proclivities between consenting adults.
 
 ## Our Standards
 


### PR DESCRIPTION
It's no secret that women in technology are in the minority both in business and in open source. By adding "sex" as a protected characteristic, this change will make it clear that contributors cannot be discriminated against on the basis of their sex—a problem recognized in many developer cultures. 