### PR TITLE
Make Hebrew display right to left

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -67,6 +67,7 @@ languageCode = "fr"
 [Languages.iw]
 languageName = "עברית"
 languageCode = "iw"
+writingDirection = "rtl"
 
 [Languages.hi]
 languageName = "हिंदी"

--- a/layouts/version/single.html
+++ b/layouts/version/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-<section>
+<section{{ with .Language.Get "writingDirection" }} dir="{{ . }}"{{ end }}>
 {{ .Content }}
 </section>
 <section class="formats">


### PR DESCRIPTION
I added a parameter called `writingDirection` to the `[Languages.iw]` section of `config.toml`.
It applies `dir="value-of-writingDirection-parameter"` to the `<section>` element containing the translated code of conduct, `rtl` in this case. This can be used for any future languages that have a writing direction other than left to right.