### PR TITLE
Fix broken links

### DIFF
--- a/content/version/1/0/0/code-of-conduct.md
+++ b/content/version/1/0/0/code-of-conduct.md
@@ -15,4 +15,4 @@ Project maintainers have the right and responsibility to remove, edit, or reject
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
 
-This Code of Conduct is adapted from the [Contributor Covenant](http:contributor-covenant.org), version 1.0.0, available at [https://www.contributor-covenant.org/version/1/0/0/](https://www.contributor-covenant.org/version/1/0/0/)
+This Code of Conduct is adapted from the [Contributor Covenant](http:contributor-covenant.org), version 1.0.0, available at https://www.contributor-covenant.org/version/1/0/0/code-of-conduct/

--- a/content/version/1/1/0/code-of-conduct.md
+++ b/content/version/1/1/0/code-of-conduct.md
@@ -17,4 +17,4 @@ This code of conduct applies both within project spaces and in public spaces whe
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
 
-This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 1.1.0, available at [https://www.contributor-covenant.org/version/1/1/0/](https://www.contributor-covenant.org/version/1/1/0/)
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 1.1.0, available at https://www.contributor-covenant.org/version/1/1/0/code-of-conduct/

--- a/content/version/1/2/0/code-of-conduct.md
+++ b/content/version/1/2/0/code-of-conduct.md
@@ -24,4 +24,4 @@ This code of conduct applies both within project spaces and in public spaces whe
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
 
-This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 1.2.0, available at [https://www.contributor-covenant.org/version/1/2/0/](https://www.contributor-covenant.org/version/1/2/0/)
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 1.2.0, available at https://www.contributor-covenant.org/version/1/2/0/code-of-conduct/

--- a/content/version/1/3/0/code-of-conduct.de.md
+++ b/content/version/1/3/0/code-of-conduct.de.md
@@ -1,5 +1,6 @@
 +++
 version = "1.3"
+aliases = ["/version/1/3/0/de/"]
 +++
 
 # Verhaltenskodex für Mitwirkende
@@ -25,4 +26,4 @@ Dieser Verhaltenskodex gilt sowohl innerhalb des Projektbereichs als auch in öf
 
 Fälle von missbräuchlichem, belästigendem oder anderweitig nicht akzeptablen Verhalten können den Projektverantwortlichen unter [EMAIL ADRESSE EINFÜGEN] gemeldet werden. Alle Beschwerden werden geprüft und untersucht, und werden zu einer Reaktion führen, die angesichts der Umstände für notwendig und angemessen gehalten wird. Die Verantwortlichen sind verpflichtet, über diejenigen, die Vorfälle gemeldet haben, Verschwiegenheit zu wahren.
 
-Dieser Verhaltenskodex ist abgeleitet vom [Contributor Covenant](https://www.contributor-covenant.org), Version 1.3.0, verfügbar unter [https://www.contributor-covenant.org/version/1/3/0/de/](https://www.contributor-covenant.org/version/1/3/0/de/)
+Dieser Verhaltenskodex ist abgeleitet vom [Contributor Covenant](https://www.contributor-covenant.org), Version 1.3.0, verfügbar unter https://www.contributor-covenant.org/de/version/1/3/0/code-of-conduct/

--- a/content/version/1/3/0/code-of-conduct.es.md
+++ b/content/version/1/3/0/code-of-conduct.es.md
@@ -1,5 +1,6 @@
 +++
 version = "1.3"
+aliases = ["/version/1/3/0/es/"]
 +++
 
 # Código de Conducta para Contribuyentes
@@ -24,4 +25,4 @@ Este código de conducta aplica, tanto a los espacios del proyecto como a espaci
 
 Ejemplos de abuso, acoso u otro comportamiento inaceptable pueden ser reportados al administrador del proyecto en [INSERTE CORREO AQUÍ]. Todas las quejas serán revisadas e investigadas, generando un resultado apropiado a las circunstancias. Los administradores tienen la obligación de mantener la confidencialidad de la persona que reportó el incidente.
 
-Este Código de Conducta es una adaptación del [Contributor Covenant](https://www.contributor-covenant.org), versión 1.3.0, disponible en [https://www.contributor-covenant.org/version/1/3/0/es/](https://www.contributor-covenant.org/version/1/3/0/es/)
+Este Código de Conducta es una adaptación del [Contributor Covenant](https://www.contributor-covenant.org), versión 1.3.0, disponible en https://www.contributor-covenant.org/es/version/1/3/0/code-of-conduct/

--- a/content/version/1/3/0/code-of-conduct.fr.md
+++ b/content/version/1/3/0/code-of-conduct.fr.md
@@ -1,5 +1,6 @@
 +++
 version = "1.3"
+aliases = ["/version/1/3/0/fr"]
 +++
 
 # Code de Conduite Contributeurs
@@ -52,5 +53,4 @@ circonstances. Les mainteneurs s'obligent à garder confidentielles les
 informations de la personne qui remonte un incident.
 
 Ce Code de Conduite est adaptée du [Contributor Covenant](https://www.contributor-covenant.org),
-version 1.3.0, disponible à
-[https://www.contributor-covenant.org/version/1/3/0/fr](https://www.contributor-covenant.org/version/1/3/0/fr)
+version 1.3.0, disponible à https://www.contributor-covenant.org/fr/version/1/3/0/code-of-conduct/

--- a/content/version/1/3/0/code-of-conduct.hu.md
+++ b/content/version/1/3/0/code-of-conduct.hu.md
@@ -1,5 +1,6 @@
 +++
 version = "1.3"
+aliases = ["/version/1/3/0/hu"]
 +++
 
 # Közreműködők Magatartási Kódexe
@@ -25,4 +26,4 @@ Ez a Magatartási Kódex érvényes mind a projekt felületén és a valós éle
 
 Bármilyen gyalázkodó, zaklatójellegű vagy egyébként elfogadhatatlan magatartást jelentse egy fenntartónak a(z) [INSERT EMAIL ADDRESS] címen. Minden egyes panasz átnézésre és kivizsgálásra, valamint a körülményeknek meglelelő válaszlépések megtételére sor kerül. A fenntartók elkötelezettek afelé hogy az incidens és a bejelentője adatai bizalmas kezelendőek.
 
-Ez a Magatartási Kódex a [Contributor Covenant](https://www.contributor-covenant.org) alapján készült. A Kódex 1.3.0 verziója megtalálható a [https://www.contributor-covenant.org/version/1/3/0/hu](https://www.contributor-covenant.org/version/1/3/0/hu) címen.
+Ez a Magatartási Kódex a [Contributor Covenant](https://www.contributor-covenant.org) alapján készült. A Kódex 1.3.0 verziója megtalálható a https://www.contributor-covenant.org/hu/version/1/3/0/code-of-conduct/ címen.

--- a/content/version/1/3/0/code-of-conduct.it.md
+++ b/content/version/1/3/0/code-of-conduct.it.md
@@ -1,5 +1,6 @@
 +++
 version = "1.3"
+aliases = ["/version/1/3/0/it"]
 +++
 
 # Codice di Comportamento del Collaboratore
@@ -25,4 +26,4 @@ Questo Codice di Comportamento è applicabile sia al progetto online che agli sp
 
 Casi di comportamento ingiurioso, molesto o altrimenti inaccettabile possono essere riportati contattando il responsabile del progetto tramite [INSERIRE INDIRIZZO EMAIL]. Tutti i reclami saranno revisionati ed indagati e risulteranno in una risposta ritenuta necessaria ed appropriata alle circostanze. I responsabili sono obbligati a manterere riserbo rispetto a chi riporta un caso.
 
-Questo Codice di Comportamento è adattato da [Contributor Covenant](https://www.contributor-covenant.org), versione 1.3.0, disponibile presso [https://www.contributor-covenant.org/version/1/3/0/it](https://www.contributor-covenant.org/version/1/3/0/it)
+Questo Codice di Comportamento è adattato da [Contributor Covenant](https://www.contributor-covenant.org), versione 1.3.0, disponibile presso https://www.contributor-covenant.org/it/version/1/3/0/code-of-conduct/

--- a/content/version/1/3/0/code-of-conduct.ja.md
+++ b/content/version/1/3/0/code-of-conduct.ja.md
@@ -1,5 +1,6 @@
 +++
 version = "1.3"
+aliases = ["/version/1/3/0/ja"]
 +++
 
 # コントリビュータの行動規範
@@ -42,6 +43,6 @@ version = "1.3"
 すべての苦情はレビュー、調査され、状況に応じて必要かつ適切と判断された
 対応を取ります。メンテナは報告者についての守秘義務を有します。
 
-この行動規範は、https://www.contributor-covenant.org/version/1/3/0/ja/ で公開
-されている [コントリビュータ協定](https://www.contributor-covenant.org) バー
-ジョン 1.3.0 に適合しています。
+この行動規範は、https://www.contributor-covenant.org/ja/version/1/3/0/code-of-conduct/
+で公開 されている [コントリビュータ協定](https://www.contributor-covenant.org)
+バー ジョン 1.3.0 に適合しています。

--- a/content/version/1/3/0/code-of-conduct.md
+++ b/content/version/1/3/0/code-of-conduct.md
@@ -48,8 +48,6 @@ incident.
 
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 1.3.0, available at
-[https://www.contributor-covenant.org/version/1/3/0/][version]
+version 1.3.0, available at https://www.contributor-covenant.org/version/1/3/0/code-of-conduct/
 
 [homepage]: https://www.contributor-covenant.org
-[version]: https://www.contributor-covenant.org/version/1/3/0/

--- a/content/version/1/3/0/code-of-conduct.pl.md
+++ b/content/version/1/3/0/code-of-conduct.pl.md
@@ -1,5 +1,6 @@
 +++
 version = "1.3"
+aliases = ["/version/1/3/0/pl"]
 +++
 
 # Kodeks postępowania współtwórców
@@ -25,4 +26,4 @@ Niniejszy kodeks stosuje się nie tylko w działaniach wprost związanych z tym 
 
 Przypadki obraźliwego, zastraszającego lub w inny sposób nieakceptowalnego zachowania mogą być zgłaszane do opiekuna tego projektu drogą elektroniczną pod adresem [TWÓJ ADRES EMAIL]. Wszystkie zażalenia i uwagi zostaną rozpatrzone i będą podstawą do analizy. W przypadku potwierdzenia się zarzutów zostaną podjęte odpowiednie do przewinienia środki zaradcze. Opiekunowie tego projektu są zobligowani do zachowania poufności danych osób zgłaszających incydent.
 
-Niniejszy Kodeks postępowania jest zgodny z [Contributor Covenant](https://www.contributor-covenant.org) w wersji 1.3.0. Oryginalny tekst można znaleźć pod adresem: [https://www.contributor-covenant.org/version/1/3/0/pl](https://www.contributor-covenant.org/version/1/3/0/pl)
+Niniejszy Kodeks postępowania jest zgodny z [Contributor Covenant](https://www.contributor-covenant.org) w wersji 1.3.0. Oryginalny tekst można znaleźć pod adresem: https://www.contributor-covenant.org/pl/version/1/3/0/code-of-conduct/

--- a/content/version/1/3/0/code-of-conduct.pt-br.md
+++ b/content/version/1/3/0/code-of-conduct.pt-br.md
@@ -1,5 +1,6 @@
 +++
 version = "1.3"
+aliases = ["/version/1/3/0/pt_br"]
 +++
 
 # Código de Conduta para Colaboradores
@@ -50,4 +51,4 @@ Os administradores são obrigados a manter a confidencialidade em relação
 ao elemento que reportou o incidente.
 
 Este Código de Conduta é adaptado do [Contributor Covenant](https://www.contributor-covenant.org),
-versão 1.3.0, disponível em [https://www.contributor-covenant.org/version/1/3/0/pt_br/](https://www.contributor-covenant.org/version/1/3/0/pt_br/)
+versão 1.3.0, disponível em https://www.contributor-covenant.org/pt-br/version/1/3/0/code-of-conduct/

--- a/content/version/1/3/0/code-of-conduct.pt.md
+++ b/content/version/1/3/0/code-of-conduct.pt.md
@@ -1,5 +1,6 @@
 +++
 version = "1.3"
+aliases = ["/version/1/3/0/pt"]
 +++
 
 # Código de Conduta para Colaboradores
@@ -50,4 +51,4 @@ Os administradores são obrigados a manter a confidencialidade em relação
 ao elemento que reportou o incidente.
 
 Este Código de Conduta é adaptado do [Contributor Covenant](https://www.contributor-covenant.org),
-versão 1.3.0, disponível em [https://www.contributor-covenant.org/version/1/3/0/pt/](https://www.contributor-covenant.org/version/1/3/0/pt/)
+versão 1.3.0, disponível em https://www.contributor-covenant.org/pt/version/1/3/0/code-of-conduct/

--- a/content/version/1/3/0/code-of-conduct.ru.md
+++ b/content/version/1/3/0/code-of-conduct.ru.md
@@ -1,5 +1,6 @@
 +++
 version = "1.3"
+aliases = ["/version/1/3/0/ru"]
 +++
 
 # Кодекс поведения автора
@@ -48,6 +49,6 @@ version = "1.3"
 Разработчики проекта обязаны сохранять конфиденциальность
 в отношении сообщившего об инциденте.
 
-Кодекс Поведения основан на [Contributor Covenant][https://www.contributor-covenant.org],
+Кодекс Поведения основан на [Contributor Covenant](https://www.contributor-covenant.org),
 версия 1.3.0, доступна на
-[https://www.contributor-covenant.org/version/1/3/0/ru/][https://www.contributor-covenant.org/version/1/3/0/ru/]
+https://www.contributor-covenant.org/ru/version/1/3/0/code-of-conduct/

--- a/content/version/1/3/0/code-of-conduct.sl.md
+++ b/content/version/1/3/0/code-of-conduct.sl.md
@@ -1,5 +1,6 @@
 +++
 version = "1.3"
+aliases = ["/version/1/3/0/sl"]
 +++
 
 # Kodeks ravnanja sodelavcev
@@ -46,8 +47,6 @@ dolžni vzdrževati zaupnost poročevalca
 incidenta.
 
 Ta kodeks ravnanja je prilagojen glede na [Pakt sodelavcev][homepage]
-verzije 1.3.0, ki je na voljo na
-[https://www.contributor-covenant.org/version/1/3/0/sl/][version]
+verzije 1.3.0, ki je na voljo na https://www.contributor-covenant.org/sl/version/1/3/0/code-of-conduct/
 
 [homepage]: https://www.contributor-covenant.org
-[version]: https://www.contributor-covenant.org/version/1/3/0/

--- a/content/version/1/4/code-of-conduct.bn.md
+++ b/content/version/1/4/code-of-conduct.bn.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4/bn"]
 +++
 
 # কনট্রিবিউটরদের আচরনবিধি
@@ -67,7 +68,6 @@ version = "1.4"
 ## অধ্যাস
 
 এই আচরনবিধি [Contributor Covenant][homepage], version 1.4 থেকে উদ্ভূত হয়েছে,
-এখানে পাওয়া যাবে [https://www.contributor-covenant.org/version/1/4][version]
+এখানে পাওয়া যাবে https://www.contributor-covenant.org/bn/version/1/4/code-of-conduct/
 
 [homepage]: https://www.contributor-covenant.org
-[version]: https://www.contributor-covenant.org/version/1/4/

--- a/content/version/1/4/code-of-conduct.bs.md
+++ b/content/version/1/4/code-of-conduct.bs.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4/bs"]
 +++
 
 # Pakt Saradnika: Kodeks Ponašanja
@@ -46,4 +47,4 @@ Održavatelji projekta koji ne prate ili primijene ovaj kodeks ponašanja mogu b
 
 ## Pripisivanje
 
-Ovaj kodeks ponašanja je preuzet iz [Contributor Covenant][https://www.contributor-covenant.org], verzija 1.4, dostupan na [https://www.contributor-covenant.org/version/1/4][https://www.contributor-covenant.org/version/1/4/].
+Ovaj kodeks ponašanja je preuzet iz [Contributor Covenant](https://www.contributor-covenant.org), verzija 1.4, dostupan na https://www.contributor-covenant.org/bs/version/1/4/code-of-conduct/

--- a/content/version/1/4/code-of-conduct.de.md
+++ b/content/version/1/4/code-of-conduct.de.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4/de"]
 +++
 
 # Vereinbarung über Verhaltenskodex für Mitwirkende
@@ -44,4 +45,4 @@ Projektverantwortliche, welche den Verhaltenskodex nicht befolgen, oder nicht na
 
 ## Bezug
 
-Dieser Verhaltenskodex basiert auf dem Contributor Covenant, Version 1.4, verfügbar unter https://www.contributor-covenant.org/version/1/4/de/
+Dieser Verhaltenskodex basiert auf dem Contributor Covenant, Version 1.4, verfügbar unter https://www.contributor-covenant.org/de/version/1/4/code-of-conduct/

--- a/content/version/1/4/code-of-conduct.el.md
+++ b/content/version/1/4/code-of-conduct.el.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4/el"]
 +++
 
 # Κώδικας δεοντολογίας «Contributor Covenant»
@@ -73,7 +74,6 @@ version = "1.4"
 
 Αυτός ο κώδικας δεοντολογίας έχει προσαρμοστεί από το
 «[Contributor Covenant][οικοσελίδα]», με αριθμό έκδοσης 1.4, διαθέσιμο από
-<[https://www.contributor-covenant.org/version/1/4][έκδοση]>.
+<https://www.contributor-covenant.org/el/version/1/4/code-of-conduct/>.
 
 [οικοσελίδα]: https://www.contributor-covenant.org
-[έκδοση]: https://www.contributor-covenant.org/version/1/4/

--- a/content/version/1/4/code-of-conduct.es.md
+++ b/content/version/1/4/code-of-conduct.es.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4/es"]
 +++
 
 # Código de Conducta convenido para Contribuyentes
@@ -44,7 +45,6 @@ Administradores que no sigan o que no hagan cumplir este Código de Conducta pue
 
 ## Atribución
 
-Este Código de Conducta es una adaptación del [Contributor Covenant][homepage], versión 1.4, disponible en [https://www.contributor-covenant.org/version/1/4/es/][version]
+Este Código de Conducta es una adaptación del [Contributor Covenant][homepage], versión 1.4, disponible en https://www.contributor-covenant.org/es/version/1/4/code-of-conduct/
 
 [homepage]: https://www.contributor-covenant.org
-[version]: https://www.contributor-covenant.org/version/1/4/es/

--- a/content/version/1/4/code-of-conduct.fr.md
+++ b/content/version/1/4/code-of-conduct.fr.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4/fr"]
 +++
 
 # Charte Code de Conduite Contributeurs
@@ -77,5 +78,5 @@ répercussions définies par d'autres membres de la direction du projet.
 
 Ce Code de Conduite est adapté du [Contributor Covenant](https://www.contributor-covenant.org),
 version 1.4.0, disponible à
-<https://www.contributor-covenant.org/version/1/4/fr>
+<https://www.contributor-covenant.org/fr/version/1/4/code-of-conduct>
 

--- a/content/version/1/4/code-of-conduct.hi.md
+++ b/content/version/1/4/code-of-conduct.hi.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4/hi"]
 +++
 
 आचार संहिता # योगदानकर्ता वाचा
@@ -72,7 +73,6 @@ version = "1.4"
 ## रोपण
 
 इस आचार संहिता [योगदानकर्ता वाचा] [मुखपृष्ठ], संस्करण 1.4 से अनुकूलित है,
-पर उपलब्ध [https://www.contributor-covenant.org/version/1/4][version]
+पर उपलब्ध https://www.contributor-covenant.org/hi/version/1/4/code-of-conduct/
 
 [मुखपृष्ठ]: https://www.contributor-covenant.org
-[संस्करण]: https://www.contributor-covenant.org/version/1/4/

--- a/content/version/1/4/code-of-conduct.iw.md
+++ b/content/version/1/4/code-of-conduct.iw.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4/iw"]
 +++
 
 # קוד התנהגות לתורם
@@ -59,7 +60,6 @@ version = "1.4"
 ## יחוס
 
 קוד התנהגות זה מותאם מאמנת התורם, גרסה 1.4, 
-הזמינה ב https://www.contributor-covenant.org/version/1/4/
+הזמינה ב https://www.contributor-covenant.org/iw/version/1/4/code-of-conduct/
 
 [homepage]: https://www.contributor-covenant.org
-[version]: https://www.contributor-covenant.org/version/1/4/

--- a/content/version/1/4/code-of-conduct.ja.md
+++ b/content/version/1/4/code-of-conduct.ja.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4/ja"]
 +++
 
 # コントリビューター行動規範
@@ -68,8 +69,7 @@ version = "1.4"
 ## 帰属
 
 この行動規範は
-[https://www.contributor-covenant.org/version/1/4][version] にある
+https://www.contributor-covenant.org/version/1/4/code-of-conduct/ にある
 [Contributor Covenant][homepage] バージョン 1.4 に適合しています。
 
 [homepage]: https://www.contributor-covenant.org
-[version]: https://www.contributor-covenant.org/version/1/4/

--- a/content/version/1/4/code-of-conduct.kn.md
+++ b/content/version/1/4/code-of-conduct.kn.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4/kn"]
 +++
 
 # ಕೊಡುಗೆದಾರರ ಒಪ್ಪಂದದ ನೀತಿ
@@ -46,7 +47,6 @@ version = "1.4"
 
 ## ಆಟ್ರಿಬ್ಯೂಷನ್
 
-ಈ ನೀತಿ ಸಂಹಿತೆಯು [ಕೊಡುಗೆದಾರರ ಒಪ್ಪಂದ][ಮುಖಪುಟ], ವರ್ಷನ 1.4, ಇಂದ ಅಳವಡಿಸಲ್ಪಟ್ಟಿದೆ ಮತ್ತು [https://www.contributor-covenant.org/version/1/4][ವರ್ಷನ] ನಲ್ಲಿ ಲಭ್ಯವಿದೆ.
+ಈ ನೀತಿ ಸಂಹಿತೆಯು [ಕೊಡುಗೆದಾರರ ಒಪ್ಪಂದ][ಮುಖಪುಟ], ವರ್ಷನ 1.4, ಇಂದ ಅಳವಡಿಸಲ್ಪಟ್ಟಿದೆ ಮತ್ತು https://www.contributor-covenant.org/kn/version/1/4/code-of-conduct/ ನಲ್ಲಿ ಲಭ್ಯವಿದೆ.
 
 [ಮುಖಪುಟ]: https://www.contributor-covenant.org
-[ವರ್ಷನ]: https://www.contributor-covenant.org/version/1/4/

--- a/content/version/1/4/code-of-conduct.ko.md
+++ b/content/version/1/4/code-of-conduct.ko.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4/ko"]
 +++
 
 # 기여자 행동 강령 규약
@@ -60,8 +61,7 @@ version = "1.4"
 ## 참고
 
 이 행동 강령은 [기여자 규약][homepage] 의 1.4 버전을 변형하였습니다. 그 내용은
-[https://www.contributor-covenant.org/version/1/4/ko][version] 에서 확인할 수
-있습니다.
+https://www.contributor-covenant.org/ko/version/1/4/code-of-conduct/ 에서
+확인할 수 있습니다.
 
 [homepage]: https://www.contributor-covenant.org
-[version]: https://www.contributor-covenant.org/version/1/4/ko/

--- a/content/version/1/4/code-of-conduct.md
+++ b/content/version/1/4/code-of-conduct.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4"]
 +++
 
 # Contributor Covenant Code of Conduct
@@ -72,7 +73,6 @@ members of the project's leadership.
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at [https://www.contributor-covenant.org/version/1/4][version]
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct/
 
 [homepage]: https://www.contributor-covenant.org
-[version]: https://www.contributor-covenant.org/version/1/4/

--- a/content/version/1/4/code-of-conduct.mk.md
+++ b/content/version/1/4/code-of-conduct.mk.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4/mk"]
 +++
 
 # Договор за Соработник - Kодекс на Oднесување
@@ -45,7 +46,6 @@ version = "1.4"
 ## Припишување
 
 Овој кодекс на однесување е прилагоден од [Contributor Covenant][homepage], верзија 1.4,
-достапна на [https://www.contributor-covenant.org/version/1/4][version]
+достапна на https://www.contributor-covenant.org/mk/version/1/4/code-of-conduct/
 
 [homepage]: https://www.contributor-covenant.org
-[version]: https://www.contributor-covenant.org/version/1/4/

--- a/content/version/1/4/code-of-conduct.nl.md
+++ b/content/version/1/4/code-of-conduct.nl.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4/nl"]
 +++
 
 # Gedragscode voor Bijdragers
@@ -71,7 +72,6 @@ de projectleiding.
 ## Attributie
 
 Deze Gedragscode is een  aangepaste versie van  de [Contributor Covenant][homepage],
-versie 1.4, beschikbaar op [https://www.contributor-covenant.org/version/1/4/nl/][version]
+versie 1.4, beschikbaar op https://www.contributor-covenant.org/nl/version/1/4/code-of-conduct/
 
 [homepage]: https://www.contributor-covenant.org
-[version]: https://www.contributor-covenant.org/version/1/4/nl/

--- a/content/version/1/4/code-of-conduct.pl.md
+++ b/content/version/1/4/code-of-conduct.pl.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4/pl"]
 +++
 
 # Przymierze Współpracy — Kodeks Postępowania
@@ -74,10 +75,8 @@ liderów projektu.
 ## Autorstwo
 
 Ten Kodeks Postępowania został zaadaptowany z [Contributor Covenant][homepage] w
-wersji 1.4, dostępnej pod adresem [https://www.contributor-covenant.org/version/1/4][version]
-(w języku angielskim) oraz [https://www.contributor-covenant.org/version/1/4/pl][version_pl]
+wersji 1.4, dostępnej pod adresem https://www.contributor-covenant.org/version/1/4/code-of-conduct/
+(w języku angielskim) oraz https://www.contributor-covenant.org/pl/version/1/4/code-of-conduct/
 (w języku polskim).
 
 [homepage]: https://www.contributor-covenant.org/
-[version]: https://www.contributor-covenant.org/version/1/4/
-[version_pl]: https://www.contributor-covenant.org/version/1/4/pl/

--- a/content/version/1/4/code-of-conduct.pt-br.md
+++ b/content/version/1/4/code-of-conduct.pt-br.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4/pt_br"]
 +++
 
 # Código de Conduta para Colaboradores
@@ -72,4 +73,4 @@ determinadas por outros membros da liderança do projeto.
 ## Atribuição
 
 Este Código de Conduta é adaptado do [Contributor Covenant](https://www.contributor-covenant.org),
-versão 1.4, disponível em [https://www.contributor-covenant.org/version/1/4/pt_br/](https://www.contributor-covenant.org/version/1/4/pt_br/)
+versão 1.4, disponível em https://www.contributor-covenant.org/pt-br/version/1/4/code-of-conduct/

--- a/content/version/1/4/code-of-conduct.pt.md
+++ b/content/version/1/4/code-of-conduct.pt.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4/pt"]
 +++
 
 # Pacto de Código de Conduta para Colaboradores
@@ -77,4 +78,4 @@ ou permanentes determinadas por outros membros da liderança do projeto.
 ## Atribuição
 
 Este Código de Conduta é adaptado do [Contributor Covenant](https://www.contributor-covenant.org),
-versão 1.4, disponível em [https://www.contributor-covenant.org/version/1/4/pt/](https://www.contributor-covenant.org/version/1/4/pt/)
+versão 1.4, disponível em https://www.contributor-covenant.org/pt/version/1/4/code-of-conduct/

--- a/content/version/1/4/code-of-conduct.ro.md
+++ b/content/version/1/4/code-of-conduct.ro.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4/ro"]
 +++
 
 # Codul de Conduită al Contributorului
@@ -69,8 +70,6 @@ alţi membrii din conducerea proiectului.
 ## Afiliere
 
 Acest Cod de Conduită este adaptat conform [Codului de Conduită al Contributorului]  
-[homepage], versiunea 1.4, disponibil la [https://www.contributor-covenant.org/version/1/4]
-[version]                                                                          
+[homepage], versiunea 1.4, disponibil la https://www.contributor-covenant.org/ro/version/1/4/code-of-conduct/
 
 [homepage]: https://www.contributor-covenant.org
-[version]: https://www.contributor-covenant.org/version/1/4/

--- a/content/version/1/4/code-of-conduct.ru.md
+++ b/content/version/1/4/code-of-conduct.ru.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4/ru"]
 +++
 
 # Кодекс Поведения участника
@@ -42,7 +43,6 @@ version = "1.4"
 
 ## Атрибуция
 
-Данный Кодекс Поведения основан на [Contributor Covenant][сайт], версия 1.4.0 доступна на [https://www.contributor-covenant.org/version/1/4/ru/][версия].
+Данный Кодекс Поведения основан на [Contributor Covenant][сайт], версия 1.4.0 доступна на https://www.contributor-covenant.org/ru/version/1/4/code-of-conduct/
 
 [сайт]: https://www.contributor-covenant.org
-[версия]: https://www.contributor-covenant.org/version/1/4/ru/

--- a/content/version/1/4/code-of-conduct.sl.md
+++ b/content/version/1/4/code-of-conduct.sl.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4/sl"]
 +++
 
 # Kodeks obnašanja zveze sodelavcev
@@ -71,7 +72,6 @@ veri, se lahko soočijo z začasnimi ali trajnimi posledicami, ki jih določijo 
 ## Dodelitev
 
 Ta kodeks ravnanja je prilagojen glede na [Zvezo sodelavcev][homepage], verzije 1.4,
-ki je na voljo na [https://www.contributor-covenant.org/version/1/4/sl/][version]
+ki je na voljo na https://www.contributor-covenant.org/sl/version/1/4/code-of-conduct/
 
 [homepage]: https://www.contributor-covenant.org
-[version]: https://www.contributor-covenant.org/version/1/4/sl/

--- a/content/version/1/4/code-of-conduct.sv.md
+++ b/content/version/1/4/code-of-conduct.sv.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4/sv"]
 +++
 
 # Medarbetarförbundets Uppförandekod
@@ -73,7 +74,6 @@ medlemmar av projektets ledning.
 ## Attribuering
 
 Denna Uppförandekod är anpassad efter [Contributor Covenant][hemsida],
-version 1.4, tillgänglig på [https://www.contributor-covenant.org/version/1/4][version]
+version 1.4, tillgänglig på https://www.contributor-covenant.org/sv/version/1/4/code-of-conduct/
 
 [hemsida]: https://www.contributor-covenant.org
-[version]: https://www.contributor-covenant.org/version/1/4/

--- a/content/version/1/4/code-of-conduct.tr.md
+++ b/content/version/1/4/code-of-conduct.tr.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4/tr"]
 +++
 
 # Katkıcı Ahdi Topluluk Sözleşmesi
@@ -67,7 +68,6 @@ karşı geçici veya kalıcı yaptırımlar uygulayabilir.
 ## Kaynak
 
 Bu Topluluk Sözleşmesi, [Contributor Covenant][homepage] 1.4 sürümünden çevrilmiştir,
-aslına bu adresten erişebilirsiniz [https://www.contributor-covenant.org/version/1/4][version]
+aslına bu adresten erişebilirsiniz https://www.contributor-covenant.org/tr/version/1/4/code-of-conduct/
 
 [homepage]: https://www.contributor-covenant.org
-[version]: https://www.contributor-covenant.org/version/1/4/

--- a/content/version/1/4/code-of-conduct.uk.md
+++ b/content/version/1/4/code-of-conduct.uk.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4/uk"]
 +++
 
 # Пакт про участь - Кодекс поведінки
@@ -71,7 +72,6 @@ version = "1.4"
 ## Посилання
 
 Цей Кодекс поведінки заснований на [Пакті про участь][homepage], версії 1.4,
-що знаходиться за адресою [https://www.contributor-covenant.org/version/1/4/uk/][version]
+що знаходиться за адресою https://www.contributor-covenant.org/uk/version/1/4/code-of-conduct/
 
 [homepage]: https://www.contributor-covenant.org
-[version]: https://www.contributor-covenant.org/version/1/4/uk/

--- a/content/version/1/4/code-of-conduct.zh-cn.md
+++ b/content/version/1/4/code-of-conduct.zh-cn.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4/cn"]
 +++
 
 # 参与者公约
@@ -49,7 +50,6 @@ version = "1.4"
 ## 来源
 
 本行为标准改编自[贡献者公约][主页]，版本 1.4
-可在此观看[https://www.contributor-covenant.org/version/1/4/](版本)
+可在此观看https://www.contributor-covenant.org/zh-cn/version/1/4/code-of-conduct/
 
 [主页]: https://www.contributor-covenant.org
-[版本]: https://www.contributor-covenant.org/version/1/4/

--- a/content/version/1/4/code-of-conduct.zh-tw.md
+++ b/content/version/1/4/code-of-conduct.zh-tw.md
@@ -1,5 +1,6 @@
 +++
 version = "1.4"
+aliases = ["/version/1/4/tw"]
 +++
 
 # 貢獻者公約
@@ -49,7 +50,6 @@ version = "1.4"
 ## 來源
 
 本行為準則改編自[貢獻者公約][首頁]，版本 1.4
-可在此觀看[https://www.contributor-covenant.org/version/1/4/][版本]
+可在此觀看https://www.contributor-covenant.org/zh-tw/version/1/4/code-of-conduct/
 
 [首頁]: https://www.contributor-covenant.org
-[版本]: https://www.contributor-covenant.org/version/1/4/


### PR DESCRIPTION
The language-specific links were broken.
I changed them to reflect the new URL structure, and added aliases for the old.
Some translations linked to the English version, and some had broken URLs, so I fixed those.
I changed the links that were linkified bare URLs to just the URL, since they get linkified anyway.