### PR TITLE
Flip margins on RTL content

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -46,6 +46,11 @@ ol {
   margin: 1.5rem 0 1.5rem 1.5rem;
 }
 
+[dir="rtl"] ul,
+[dir="rtl"] ol {
+  margin: 1.5rem 1.5rem 1.5rem 0;
+}
+
 li {
   margin-bottom: .375rem;
 }


### PR DESCRIPTION
Unfortunately, `margin-start`/`margin-end` aren't widely supported.
This makes the lists non-goofy on the Hebrew translation.