### PR TITLE
Fix sporadically incorrect language names

### DIFF
--- a/layouts/partials/translation-row.html
+++ b/layouts/partials/translation-row.html
@@ -3,7 +3,7 @@
     {{ partial "file-formats.html" . }}
   </td>
   <td>
-    <a href="{{ .Permalink | absLangURL }}">{{ .Site.Language.LanguageName }}</a>
+    <a href="{{ .Permalink | absLangURL }}">{{ .Language.LanguageName }}</a>
   </td>
   <td>{{ .Params.version }}</td>
 </tr>


### PR DESCRIPTION
Finally figured out that pesky bug, and now I feel silly.