### PR TITLE
Remove Markdown escaping in CSV file

### DIFF
--- a/data/featured-adopters.csv
+++ b/data/featured-adopters.csv
@@ -45,7 +45,7 @@ Swift, https://swift.org/community/#code-of-conduct
 Taiga.io, https://github.com/taigaio/code-of-conduct
 TinyMCE, https://www.tinymce.com/docs/advanced/contributing-to-open-source/
 Twisted, https://github.com/twisted/twisted
-Visual F\#, https://github.com/Microsoft/visualfsharp
+Visual F#, https://github.com/Microsoft/visualfsharp
 Volt.rb, https://github.com/voltrb/volt
 Vue.js, https://github.com/vuejs/vue
 Yarn, https://github.com/yarnpkg/yarn


### PR DESCRIPTION
Missed this when moving stuff into CSV.
Apologies to F#.