### PR TITLE
Add support for asciidoc versions of covenant

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -16,6 +16,9 @@ googleAnalytics = "UA-56802475-1"
 [mediaTypes."text/markdown"]
 suffix = "md"
 
+[mediaTypes."text/asciidoc"]
+suffix = "adoc"
+
 [outputFormats]
 [outputFormats.Markdown]
 mediaType = "text/markdown"
@@ -25,9 +28,13 @@ isPlainText = true
 mediaType = "text/plain"
 isPlainText = true
 
+[outputFormats.AsciiDoc]
+mediaType = "text/asciidoc"
+isPlainText = true
+
 [outputs]
 home = ["html"]
-page = ["html", "markdown", "plaintext"]
+page = ["html", "markdown", "plaintext", "asciidoc"]
 
 # Add all translated languages here.
 [Languages]

--- a/layouts/partials/file-formats.html
+++ b/layouts/partials/file-formats.html
@@ -6,4 +6,7 @@
   <dd>
     <a class="icon icon-txt" href="{{ .Permalink | replaceRE "\\.html$" ".txt" | absLangURL }}"><abbr title="Plain text">txt</abbr></a>
   </dd>
+  <dd>
+    <a class="icon icon-adoc" href="{{ .Permalink | replaceRE "\\.html$" ".adoc" | absLangURL }}"><abbr title="AsciiDoc">adoc</abbr></a>
+  </dd>
 </dl>

--- a/layouts/version/single.adoc
+++ b/layouts/version/single.adoc
@@ -1,0 +1,1 @@
+Hello, world!

--- a/layouts/version/single.adoc
+++ b/layouts/version/single.adoc
@@ -1,1 +1,14 @@
-Hello, world!
+{{- /*
+Very hacky way of converting markdown to asciidoc.
+Because the covenant uses rather simple syntax, we can get away with this :)
+
+Order of operations is:
+* Replace markdown # headers for = asciidoc
+* Transform links in the form of [text][reference] to text + remove reference links at end.
+  This is similar to what the txt conversion does, and it's very hard to convert with just regexps -- if we want to
+  keep these links it'll probably be easier to just convert them to [text](url) format.
+* Transform links in the form of [text](url) to asciidoc's link:url[text]
+* Transform links in the <url> form to asciidoc's link:url[url]
+
+*/ -}}
+{{ .RawContent | replaceRE "#" "=" | replaceRE "\\[([^\\]]*)\\][ \\n]*\\[[^\\]]*\\]" "$1" | replaceRE "\\[[^\\]]*\\]: .*" "" | replaceRE "\\[([^\\]]*)\\]\\((https{0,1}:.*)\\)" "link:$2[$1]" | replaceRE "<(https{0,1}:.*)>" "link:$1[$1]" | safeHTML }}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -252,6 +252,10 @@ abbr {
   background: hsl(42, 80%, 50%);
 }
 
+.icon-adoc {
+  background: hsl(201, 80%, 35%);
+}
+
 .icon:hover {
   background-color: hsl(288, 80%, 35%);
   color: #fff;
@@ -263,6 +267,10 @@ abbr {
 
 .icon-txt:hover {
   background: hsl(42, 80%, 60%);
+}
+
+.icon-adoc:hover {
+  background: hsl(201, 80%, 45%);
 }
 
 .formats {


### PR DESCRIPTION
This PR adds a new template to convert the covenant to asciidoc, as well as links to this new version to the webpage.

It also includes a quick fix for the Hindi covenant, where I noticed that the markup was wrong.

The markdown-to-asciidoc conversion is not a great implementation, but it suffices for all current and past covenant versions. Hopefully by the time a more complex conversion is needed (if ever) Hugo will have added native support for asciidoc.

Fixes #488