### PR TITLE
Add education and socio-economic status

### DIFF
--- a/content/version/1/4/code-of-conduct.md
+++ b/content/version/1/4/code-of-conduct.md
@@ -11,8 +11,8 @@ In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to making participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, gender identity and expression, level of experience,
-nationality, personal appearance, race, religion, or sexual identity and
-orientation.
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
 
 ## Our Standards
 


### PR DESCRIPTION
This pull request extends the definition of inclusivity to cover people's socio-economic status and level of education.

## Rationale

Volunteer communities in general, and open source software in particular, can be unwelcoming places for people from poorer backgrounds or without a university/college education. Wealthy, educated people - which most open source contributors are - can easily dismiss contributions from such users through rhetorical skill, through sniping on grammar/spelling etc., and through belitting their concerns as not representative of the empowered, educated group.

The result is products/software that reflect only the values of an already privileged part of society, and are only useful to that part. 30 years ago computers were chiefly used by the wealthy and educated: that is no longer the case.

We are increasingly seeing (Trump, Brexit etc.) a disconnect between the privileged wealthy/educated classes and the poorer/less well educated. The resulting sense of powerlessness for a majority of the world's population is clearly a massive issue in itself. But so too is the polarised atmosphere it creates (Twitter 'egg' abuse etc.), which reduces the chances of building something inclusive and good. We can and should address this.

## Examples of what this change would achieve

* Discourages grammar/spelling flames against less well educated contributors
* Discourages language exclusive of socio-economic status ("redneck", "chav" etc.)
* Discourages language exclusive of educational background or achievement ("you are too stupid to understand", etc.)
* Encourages contributors to consider design decisions which would make their software/products open to people from all backgrounds
* Encourages an awareness that the work/family commitments of contributors from less well-off backgrounds may limit their free time to respond to issues/comments
* Encourages project maintainers to actively attract contributors from a wider background rather than just "people like them" (i.e. university/college/Silicon Valley)

## Background

For 10+ years I've run a successful community site, based entirely on volunteer contributions, with its own mandatory code of conduct. The community in question (a small town near Oxford, UK) is, on average, wealthy and well educated. However, there are areas of council/social housing (aka "public housing" in American English, I think) where typically residents have not benefited from as good an education, and have less well-paying jobs.

Increasingly I have noticed that contributors from these areas find it hard to articulate their views on the site without being shot down by the wealthier, more educated majority. This might take the form of the majority criticising minority contributors over minutiae (small sincerely-believed factual inaccuracies, grammar/spelling); or a deliberate unwillingness to tolerate assumptions that differ from the majority; or constructing means of engagement/consultation that are less open to those from poorer backgrounds (evening meetings arranged which are effectively closed to those unable to get childcare, etc.).

Locally I've managed this by individual interventions, whether public (on the site) or through private messaging etc. Since noticing it here, however, I've become aware that it is absolutely endemic to online volunteer communities. By and large, open source is middle-class people using their copious leisure time to build sites and tools for other middle-class people.

My open-source background is largely in the OpenStreetMap project where there has been a fair amount of academic research done into contributor biases (particularly, though not entirely, through the work of Professor Muki Haklay). The result of such bias is easy to visualise in OSM: wealthy areas such as London or San Francisco are mapped in much more detail than poorer areas such as the Welsh Valleys or the rural American Midwest. However, although the prevailing open-source narrative has led to a fair amount of (welcome) discussion as to how we can welcome and help those groups traditionally considered marginalised in technology, there has been little or no thought given to how we make ourselves more welcoming to poorer or less well educated people. Indeed, there are instances of where such contributors have received a hostile reception on the project's communication channels (mailing lists, on-site discussions).

Thanks for your time and consideration.