### PR TITLE
Added Node.js Africa

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -101,6 +101,7 @@ MyPaint, https://github.com/mypaint/mypaint
 NColony, https://github.com/moshez/ncolony
 Neos, https://www.neos.io/
 Nerd Fonts, https://github.com/ryanoasis/nerd-fonts
+Nodejs Africa, https://nodejs.africa/
 .NET Foundation, http://www.dotnetfoundation.org/code-of-conduct
 nteract, http://nteract.io/
 OAPI ShieldsUp, https://github.com/oapi/shieldsup


### PR DESCRIPTION
Node.js Africa is an open source organization established to expand the growth of Node.js in Africa.

For more visit [Node.js Africa on GitHub](https://github.com/nodejsafrica)