### PR TITLE
Romanian translation: fixed diacritical marks, various typos

### DIFF
--- a/content/version/1/4/code-of-conduct.ro.md
+++ b/content/version/1/4/code-of-conduct.ro.md
@@ -3,73 +3,73 @@ version = "1.4"
 aliases = ["/version/1/4/ro"]
 +++
 
-# Codul de Conduită al Contributorului
+# Codul de Conduită al Contribuitorului
 
 ## Angajamentul nostru 
 
-În scopul de a menţine un mediu deschis şi primitor, noi, în rolul de contributori
-şi întreţinători ne angajăm ca participarea în proiectul şi comunitatatea noastră
-să fie o experienţă lipsită de neplăceri pentru toată lumea fără deosebire de vârstă,
-aspect fizic, dizabilitate, origine etnică, identitate sau orientare personală, nivel
-de experienţă, naţionalitate, rasă, religie şi identitate sau orientare sexuală.
+În scopul de a menține un mediu deschis și primitor, noi, în rolul de contribuitori
+și întreținători ne angajăm ca participarea în proiectul și comunitatatea noastră
+să fie o experiență lipsită de neplăceri pentru toată lumea, indiferent de vârstă, talie, 
+dizabilitate, etnie, identitate sau exprimare a genului, nivel de experiență, educație, 
+statut socio-economic, naționalitate, aspect fizic, rasă, religie, identitate sau orientare sexuală.
 
 ## Standardele noastre
 
 Exemple de comportament care contribuie la crearea unui mediu pozitiv includ:
 
-* Folosirea unui limbaj politicos şi inclusiv.
-* Respectarea punctelor de vedere şi a experienţelor alternative.
+* Folosirea unui limbaj politicos și incluziv.
+* Respectarea punctelor de vedere și a experiențelor diferite.
 * Acceptarea criticilor constructive într-un mod civilizat.
-* Orientarea către binele comunitătii.
-* Exprimarea empatiei faţă de ceilalţi membrii ai comunităţii.
+* Orientarea către binele comunității.
+* Exprimarea empatiei față de ceilalți membri ai comunității.
 
 Exemple de comportament neadecvat ale unui participant includ:
 
 * Folosirea unor expresii, imagini sau aluzii cu tentă sexuală.
 * Adresarea unor comentarii cu caracter de batjocură sau insultă. Atacuri de natură
 politică sau personală.
-* Hărţuire publică sau privată.
-* Publicarea informaţiilor private ale altor utilizatori, de exemplu adrese fizice
+* Hărțuire publică sau privată.
+* Publicarea informațiilor private ale altor utilizatori, de exemplu adrese fizice
 sau electronice, fără acceptul explicit al acestora.
 * Alt comportament care ar putea fi considerat neadecvat într-un cadru profesional.
 
-## Responsabilităţile noastre
+## Responsabilitățile noastre
 
-Cei care întreţin proiectul sunt responsabili pentru clarificarea standardelor unui
-comportament acceptabil şi trebuie să ia măsurile potrivite în cazul unor acţiuni
+Cei care întrețin proiectul sunt responsabili pentru clarificarea standardelor unui
+comportament acceptabil și trebuie să ia măsurile potrivite în cazul unor acțiuni
 considerate neadecvate.
 
-Cei care întreţin proiectul au dreptul şi responsabilitatea de a şterge, modifica
-sau respinge comentarii, contribuţii de cod sursă, modificări ale documentaţiei,
-probleme sau orice alte contribuţii care nu respectă acest Cod de Conduită sau de a
-exclude temporar sau permanent oricare contributor pentru acţiuni pe care le
-consideră neadecvate, ameninţătoare, ofensatoare sau periculoase.
+Cei care întrețin proiectul au dreptul și responsabilitatea de a șterge, modifica
+sau respinge comentarii, contribuții de cod sursă, modificări ale documentației,
+probleme sau orice alte contribuții care nu respectă acest Cod de Conduită sau de a
+exclude temporar sau permanent oricare contribuitor pentru acțiuni pe care le
+consideră neadecvate, amenințătoare, ofensatoare sau periculoase.
 
 ## Scop
 
-Acest Cod de Conduită se aplică atât în spaţiul privat cât şi în cel public atunci
+Acest Cod de Conduită se aplică atât în spațiul privat cât și în cel public atunci
 când o persoană reprezintă proiectul sau comunitatea sa. Exemple de reprezentare a
-proiectului sau a comunităţii includ folosirea unei adrese oficiale de email a
-proiectului, postarea pe reţele de socializare folosind un cont oficial sau participarea
+proiectului sau a comunității includ folosirea unei adrese oficiale de email a
+proiectului, postarea pe rețele de socializare folosind un cont oficial sau participarea
 la un eveniment 'online' sau 'offline' ca reprezentant delegat. Reprezentarea
-unui proiect poate fi clarificată în detaliu de către întreţinatorii proiectului.                                 
+unui proiect poate fi clarificată în detaliu de către întreținătorii proiectului.                                 
 
-## Condiţii de aplicare
+## Condiții de aplicare
 
-Acţiunile abuzive, hărţuitoare sau considerate neadecvate pot fi raportate prin
-contactarea echipei proiectului la adresa [INSERAŢI ADRESA DE EMAIL]. Toate plângerile
-vor fi analizate şi investigate şi vor rezulta într-un răspuns care este necesar şi
-adecvat circumstanţelor. Echipa proiectului este obligată la păstrarea confidentialităţii
-persoanei care raportează un incident. Mai multe criterii şi condiţii de aplicare pot fi
+Acțiunile abuzive, hărțuitoare sau considerate neadecvate pot fi raportate prin
+contactarea echipei proiectului la adresa [INSERAȚI ADRESA DE EMAIL]. Toate plângerile
+vor fi analizate și investigate și vor rezulta într-un răspuns care este necesar și
+adecvat circumstanțelor. Echipa proiectului este obligată la păstrarea confidentialității
+persoanei care raportează un incident. Mai multe criterii și condiții de aplicare pot fi
 specificate separat.
 
-Înterţinătorii proiectului care nu respectă şi nu aplică Codul de Conduită în bună
-credinţă, ar putea suferi repercursiuni temporare sau permanente determinate de către
-alţi membrii din conducerea proiectului.                       
+Întreținătorii proiectului care nu respectă și nu aplică Codul de Conduită în bună
+credință, ar putea suferi repercusiuni temporare sau permanente determinate de către
+alți membri din conducerea proiectului.                       
 
 ## Afiliere
 
-Acest Cod de Conduită este adaptat conform [Codului de Conduită al Contributorului]  
+Acest Cod de Conduită este adaptat conform [Codului de Conduită al Contribuitorului]  
 [homepage], versiunea 1.4, disponibil la https://www.contributor-covenant.org/ro/version/1/4/code-of-conduct.html
 
 [homepage]: https://www.contributor-covenant.org


### PR DESCRIPTION
I've updated the Romanian translation to use the correct diacritical marks — ș and ț, respectively. I've also used _contribuitor_ instead of _contributor_, and fixed some typos.