### PR TITLE
Make adopter count consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Contributor Covenant
 ====================
 
-The most popular code of conduct for open source projects with over 30,000 adoptions.
+The most popular code of conduct for open source projects with over 40,000 adoptions.
 
 ## Project Home Page
 


### PR DESCRIPTION
In the header, the README says "over 30,000" adoption; in examples it says "more than 40,000".

This PR makes the two consistent (both 40,000).

Note, though, that the search link in the bottom returns ~37,000 results, so might want to standardize them both on 35,000, or...?