### PR TITLE
port GDS readability changes

### DIFF
--- a/content/version/1/4/code-of-conduct.md
+++ b/content/version/1/4/code-of-conduct.md
@@ -7,72 +7,93 @@ aliases = ["/version/1/4"]
 
 ## Our Pledge
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+In order to create an open and welcoming environment, we as contributors and
+maintainers pledge to make participation in our project and our community a
+harassment-free experience for everyone, regardless of:
+
+* age
+* body size
+* disability
+* ethnicity
+* sex characteristics
+* gender identity and expression
+* level of experience
+* education
+* socio-economic status
+* nationality
+* personal appearance
+* race
+* religion
+* sexual identity and orientation
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment
-include:
+You can contribute to creating a positive environment in many ways. For example
+participants can:
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+* use welcoming and inclusive language
+* be respectful of differing viewpoints and experiences
+* accept constructive criticism gracefully
+* focus on what is best for the community
+* show empathy towards other community members
 
-Examples of unacceptable behavior by participants include:
+You must not:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
-  advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+* use sexualized language or imagery
+* make unwelcome sexual advances
+* troll, and make insulting or derogatory comments
+* make personal or political attacks
+* harass others, in public or private
+* publish others' private information, such as a physical or electronic address, without explicit permission
+* engage in any other conduct which could reasonably be considered inappropriate in a professional setting
+
 
 ## Our Responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+As project maintainers, we are responsible for clarifying the standards of
+acceptable behavior and we are expected to take appropriate and fair corrective
+action in response to any instances of unacceptable behavior.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+We have the right and responsibility to remove, edit, or reject:
+
+* comments
+* commits
+* code
+* wiki edits
+* issues
+* other contributions that are not aligned to this code of conduct
+
+We also reserve the right to temporarily or permanently ban any contributor for
+other behaviors we deem inappropriate, threatening, offensive, or harmful.
+
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+This code of conduct applies both within project spaces and in public spaces
+when you are representing the project or community. For example you may be:
+
+* using an official project e-mail address
+* posting via an official social media account
+* acting as an appointed representative at an online or offline event
+
+Project maintainers may further define and clarify representation of a project.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [INSERT EMAIL ADDRESS]. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+You should report any instances of abusive, harassing, or otherwise unacceptable
+behavior to the project team at [INSERT EMAIL ADDRESS]. The project team will
+review and investigate all complaints, and will respond in a way that it deems
+appropriate to the circumstances. The project team is obligated to maintain the
+confidentiality of the reporter of an incident. We may post further details of
+specific enforcement policies separately.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
+Project maintainers who do not follow or enforce this code of conduct in good
+faith may face temporary or permanent consequences. These will be determined by
 members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This code of conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html][version]
 
 [homepage]: https://www.contributor-covenant.org
+[version]: hhttps://www.contributor-covenant.org/version/1/4/code-of-conduct.html

--- a/content/version/1/4/code-of-conduct.md
+++ b/content/version/1/4/code-of-conduct.md
@@ -96,4 +96,4 @@ members of the project's leadership.
 This code of conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html][version]
 
 [homepage]: https://www.contributor-covenant.org
-[version]: hhttps://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+[version]: https://www.contributor-covenant.org/version/1/4/code-of-conduct.html


### PR DESCRIPTION
Noticed issue #498 and thought I'd go ahead and submit a PR for it.

Changes I made to the GDS version, besides the obvious (remove their email address!):
- en_GB-> en_US (behaviour->behavior, for example)
- fix some omissions from the list of protected categories (presumably caused by updates to master)
- in "Our Standards", change GDS's "you should not" to "you must not"; following the RFC 2119 senses of those words.
- In "Scope" section, I mostly reverted back to original language because I know that's a sensitive area. I kept only changes that were inarguably purely for readability. Maintainers may want to review GDS's changes further to see if more could be cherry picked - they're mostly quite good, I think.

Two things that could be discussed:
- GDS changes made some changes from "participant" to "you", and "maintainers" to "we". I like both of those changes, I think? But it does change the tone a fair bit (becomes slightly more us v. them?) so I want to literally sleep on it some more.
- instead of the long bullet list of contribution types in "Our Responsibilities", I'd consider just "remove or edit any change or contribution". 