### PR TITLE
Add PyMC3 to list of adopters

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -140,6 +140,7 @@ Pre-filled repository, https://github.com/GuglielmoPepe/pre-filled-repository
 Pressbooks, https://github.com/pressbooks/pressbooks
 ProcessIterator, https://github.com/console-helpers/process-iterator
 PyBBIO, https://github.com/graycatlabs/PyBBIO
+PyMC3, https://github.com/pymc-devs/pymc3
 Python-dwca-reader, https://github.com/BelgianBiodiversityPlatform/python-dwca-reader
 QA-Tools, https://github.com/qa-tools/qa-tools
 Quack Lang, https://github.com/quack/quack


### PR DESCRIPTION
PyMC3's code of conduct can be found [here](https://github.com/pymc-devs/pymc3/blob/master/CODE_OF_CONDUCT.md).