### PR TITLE
Fix latin and cyrillics mix in Russian languageName

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -135,7 +135,7 @@ languageName = "Română"
 languageCode = "ro"
 
 [Languages.ru]
-languageName = "Pусский"
+languageName = "Русский"
 languageCode = "ru"
 
 [Languages.sl]


### PR DESCRIPTION
First letter was latin "P" instead of Russian "Р". Such mix makes it impossible to search for Russian version in browser. 