### PR TITLE
Fix potential for abuse

### DIFF
--- a/content/version/1/4/code-of-conduct.md
+++ b/content/version/1/4/code-of-conduct.md
@@ -28,11 +28,13 @@ include:
 Examples of unacceptable behavior by participants include:
 
 * The use of sexualized language or imagery and unwelcome sexual attention or
-  advances
+  advances after being advised of its unwelcomeness
 * Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
+* Repeated public or private harassment
 * Publishing others' private information, such as a physical or electronic
   address, without explicit permission
+* Attacking or villainizing project members over political or personal
+  beliefs and statements which are unrelated to the project's mission
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
@@ -54,8 +56,7 @@ This Code of Conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community. Examples of
 representing a project or community include using an official project e-mail
 address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+representative at an online or offline event.
 
 ## Enforcement
 

--- a/content/version/1/4/code-of-conduct.md
+++ b/content/version/1/4/code-of-conduct.md
@@ -34,21 +34,21 @@ Examples of unacceptable behavior by participants include:
 * Publishing others' private information, such as a physical or electronic
   address, without explicit permission
 * Attacking or villainizing project members over political or personal
-  beliefs and statements which are unrelated to the project's mission
+  beliefs and statements which are unrelated to the project
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Our Responsibilities
 
 Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+behavior and are expected to take appropriate, fair, and just corrective action
+in response to any instances of unacceptable behavior.
 
 Project maintainers have the right and responsibility to remove, edit, or
 reject comments, commits, code, wiki edits, issues, and other contributions
 that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+permanently any contributor for other project-related behaviors that they 
+deem inappropriate, threatening, offensive, or harmful.
 
 ## Scope
 


### PR DESCRIPTION
Many people have raised concerns that this document creates a chilling effect.  This CoC could be used by political opponents and trolls to attack project members for "thought crimes".  These proposed changes should help prevent that type of abuse by making what people do in their free time irrelevant to this document.