### PR TITLE
Add Heptio OSS projects

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -71,6 +71,10 @@ Golden Cobra, https://github.com/ikuseiGmbH/Goldencobra
 GoReleaser, https://github.com/goreleaser/releaser
 Hacken.in, https://github.com/hacken-in/website
 Hanami, http://hanamirb.org/community#code-of-conduct
+Heptio Ark, https://github.com/heptio/ark
+Heptio Contour, https://github.com/heptio/contour
+Heptio Gimbal, https://github.com/heptio/gimbal
+Heptio Sonobuoy, https://github.com/heptio/sonobuoy
 HandBrake, https://github.com/HandBrake/HandBrake
 Haskell Fill in the Blanks, https://gitlab.com/cpp.cabrera/haskell-fill-in-the-blanks/tree/master
 HaskellNow.org, http://www.haskellnow.org/wiki/WikiStart#Projects


### PR DESCRIPTION
Ark, Contour, Gimbal and Sonobuoy

Being that Heptio is a CNCF member, we also abide by their CoC and that
is where the contact information is for any CoC violation. This is the
same as with the Kubernetes project. CNCF also abides by the Contributor Covenant.

Reference:
https://github.com/cncf/foundation/blob/master/code-of-conduct.md