### PR TITLE
Remove duplicated .Net foundation reference

### DIFF
--- a/static/featured-adopters.csv
+++ b/static/featured-adopters.csv
@@ -13,7 +13,6 @@ Crystal, https://github.com/manastech/crystal
 curl, https://github.com/bagder/curl
 Diaspora, http://github.com/diaspora/diaspora
 Discourse, https://github.com/discourse/discourse
-Dotnet Foundation, http://www.dotnetfoundation.org/code-of-conduct
 Eclipse, https://eclipse.org
 Electron, https://github.com/electron/electron
 Elixir, https://github.com/elixir-lang/elixir


### PR DESCRIPTION
.Net Foundation seems to be listed twice (same link).