### PR TITLE
Adopters: Add Codebridge (South Africa)

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -30,6 +30,7 @@ chef-rvm, https://github.com/fnichol/chef-rvm
 clearwater.rb, https://github.com/clearwater-rb/clearwater
 CloudI, http://cloudi.org/faq.html#2_CodeOfConduct
 CocoaPods, https://github.com/cocoapods/cocoapods
+Codebridge, https://github.com/codebridge-za
 CodeBuddies, https://github.com/codebuddiesdotorg/cb-v2-scratch
 composer, https://github.com/composer/composer
 concurrent-ruby, https://github.com/ruby-concurrency/concurrent-ruby


### PR DESCRIPTION
Codebridge is a South African community working on civic tech and social change:

* https://github.com/codebridge-za
* http://codebridge.org.za/