### PR TITLE
adopters.csv: Add Intel Open Source Technology Center (OTC)

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -88,6 +88,7 @@ HTML5 Boilerplate, https://github.com/h5bp/html5-boilerplate
 HTTPotion, https://github.com/myfreeweb/httpotion
 Huh? iOS, https://github.com/Yaapete/Huh-iOS
 if me, https://github.com/julianguyen/ifme
+Intel Open Source Technology Center (OTC), https://01.org/blogs/2018/intel-covenant-code
 iText, http://itextpdf.com/
 Jekyll, https://github.com/jekyll/jekyll
 jekyll-octopod, https://jekyll-octopod.github.io/conduct/

--- a/static/featured-adopters.csv
+++ b/static/featured-adopters.csv
@@ -24,6 +24,7 @@ Golang, https://golang.org/conduct
 Google, https://opensource.google.com/docs/releasing/template/CODE_OF_CONDUCT/
 Grav, https://github.com/getgrav/grav
 Homebrew-Cask, https://github.com/caskroom/homebrew-cask
+Intel Open Source Technology Center (OTC), https://01.org/blogs/2018/intel-covenant-code
 Jekyll, https://github.com/jekyll/jekyll
 Jenkins, https://jenkins-ci.org/conduct/
 Johnny-Five, https://github.com/rwaldron/johnny-five


### PR DESCRIPTION
We're not only adopting the Contributor Covenant for our projects and
the behavior of our developers, we're also encouraging others to do the
same: "We'll also work with the many communities we support and
contribute to, and recommend that these communities adopt the
Contributor Covenant as well."