### PR TITLE
"open source" changed to "open" when describing CC license

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,5 +66,5 @@ For a partial list, see [our adopters page](https://www.contributor-covenant.org
 
 ## License
 
-The Contributor Covenant is open source and free culture released under the terms of the 
+The Contributor Covenant is free and open, released under the terms of the 
 [Creative Commons Attribution 4.0 International](LICENSE.md) public license.


### PR DESCRIPTION
Suggest that "open source" is incorrect for describing this project's Creative Commons documents which are text only. "Open Source" implies source code.
I propose that "free culture" be replaced by "free", as "free culture" is not defined within this document and will be confusing to many readers, especially readers who are new to Open Source communities.