### PR TITLE
add adopter: CHAOSS project

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -26,6 +26,7 @@ Celluloid, https://github.com/celluloid/celluloid
 Cesium, https://github.com/AnalyticalGraphicsInc/cesium
 Chalk, https://github.com/chalk/chalk
 Changelog.com, https://changelog.com/
+CHAOSS Project, https://chaoss.community/
 Checkstyle for Haxe, https://github.com/HaxeCheckstyle/haxe-checkstyle
 chef-rvm, https://github.com/fnichol/chef-rvm
 clearwater.rb, https://github.com/clearwater-rb/clearwater


### PR DESCRIPTION
The CHAOSS project adopted the Contributor Covenant version 1.4 with their own changes: https://chaoss.community/about/code-of-conduct/