### PR TITLE
Improving code-of-conduct.id.md, with meaning.

### DIFF
--- a/content/version/1/4/code-of-conduct.id.md
+++ b/content/version/1/4/code-of-conduct.id.md
@@ -7,7 +7,7 @@ aliases = ["/version/1/4"]
 
 ## Ikrar Kami
 
-Dalam minat kami untuk menumbuhkan lingkungan yang terbuka dan ramah, kami sebagai 
+Dalam minat kami untuk menumbuhkan lingkungan yang terbuka dan ramah, kami sebagai
 kontributor dan pengelola berjanji untuk membuat partisipasi dalam proyek kami
 dan komunitas kami bebas dari pelecehan bagi semua orang, tanpa memandang usia,
 ukuran tubuh, disabilitas, kelompok etnis, identitas gender dan ekspresinya, tingkat pengalaman, pendidikan, status sosial ekonomi, kewarganegaraan, penampilan pribadi, ras, agama, atau identitas dan orientasi seksual.
@@ -49,7 +49,7 @@ mewakili sebuah proyek atau komunitas termasuk dalam menggunakan alamat email re
 
 Kejadian perilaku kasar, pelecehan, atau tidak dapat diterima yang terjadi
 dapat dilaporkan kepada tim inti proyek di [INSERT EMAIL ADDRESS]. Semua keluhan
-akan ditinjau, diselidiki dan akan menghasilkan tanggapan yang dianggap perlu 
+akan ditinjau, diselidiki dan akan menghasilkan tanggapan yang dianggap perlu
 dan sesuai dengan keadaan. Tim inti proyek berkewajiban menjaga kerahasiaan pelapor yang berkenaan dengan laporan suatu insiden. Rincian lebih lanjut tentang kebijakan penegakan khusus akan dipublikasikan secara terpisah.
 
 Pengelola proyek yang tidak mengikuti atau melaksanakan Kode Etik dengan itikad
@@ -59,7 +59,7 @@ oleh para anggota lain dari pimpinan proyek.
 ## Atribut
 
 Kode Etik ini diadaptasi dari [Contributor Covenant][homepage], versi 1.4,
-tersedia di [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html] [version]
+tersedia di [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html][version]
 
 [homepage]: https://www.contributor-covenant.org
 [version]: http://contributor-covenant.org/version/1/4/

--- a/content/version/1/4/code-of-conduct.id.md
+++ b/content/version/1/4/code-of-conduct.id.md
@@ -59,6 +59,7 @@ oleh para anggota lain dari pimpinan proyek.
 ## Atribut
 
 Kode Etik ini diadaptasi dari [Contributor Covenant][homepage], versi 1.4,
-tersedia di [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html][version]
+tersedia di [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html] [version]
 
 [homepage]: https://www.contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/content/version/1/4/code-of-conduct.id.md
+++ b/content/version/1/4/code-of-conduct.id.md
@@ -5,17 +5,16 @@ aliases = ["/version/1/4"]
 
 # Kode Etik Contributor Covenant
 
-## Janji Kami
+## Ikrar Kami
 
-Sesuai minat kami untuk membuat lingkungan yang terbuka dan ramah, kami sebagai 
+Dalam minat kami untuk menumbuhkan lingkungan yang terbuka dan ramah, kami sebagai 
 kontributor dan pengelola berjanji untuk membuat partisipasi dalam proyek kami
-dan komunitas kami bebas dari pelecehan untuk semua orang, tanpa memandang usia,
+dan komunitas kami bebas dari pelecehan bagi semua orang, tanpa memandang usia,
 ukuran tubuh, disabilitas, kelompok etnis, identitas gender dan ekspresinya, tingkat pengalaman, pendidikan, status sosial ekonomi, kewarganegaraan, penampilan pribadi, ras, agama, atau identitas dan orientasi seksual.
 
 ## Standar Kami
 
-Kejadian perilaku yang berkontribusi untuk menciptakan sebuah lingkungan
-yang positif meliputi :
+Contoh perilaku dalam berkontribusi yang baik untuk menciptakan sebuah lingkungan yang positif meliputi :
 
 * Memakai bahasa yang ramah dan inklusif
 * Menghormati sudut pandang dan pengalaman yang berbeda
@@ -26,34 +25,32 @@ yang positif meliputi :
 Contoh perilaku yang tidak dapat diterima oleh partisipan meliputi :
 
 * Penggunaan bahasa atau citra seksual dan perhatian seksual yang tidak diinginkan.
-* Trolling, komentar menghina, dan serangan terhadap individual atau pandangan politik.
-* Pelecahan umum atau pribadi
-* Menerbitkan informasi pribadi orang lain, seperti alamat fisik atau elektronik,
-tanpa izin.
-* Perilaku lain yang dapat dianggap tidak sesuai dalam lingkungan profesional
+* Trolling, komentar menghina/merendahkan, dan serangan terhadap individual atau pandangan politik.
+* Pelecahan secara umum atau pribadi
+* Menerbitkan informasi pribadi orang lain, seperti alamat fisik atau elektronik, tanpa izin.
+* Perilaku lain yang secara wajar dapat dianggap tidak sesuai dalam lingkungan profesional
 
 ## Tanggung Jawab Kami
 
-Pengelola proyek bertanggung jawab untuk mengklarifikasi standar perilaku yang dapat diterima dan diharapkan untuk melakukan tindakan korektif yang tepat dan adil dalam menanggapi kasus perilaku yang tidak dapat diterima.
+Pengelola proyek bertanggung jawab untuk mengklarifikasi standar perilaku yang dapat diterima dan diharapkan untuk melakukan tindakan korektif yang tepat dan adil dalam menanggapi setiap kasus perilaku yang tidak dapat diterima.
 
 Pengelola proyek mempunyai hak dan tanggung jawab untuk menghapus, mengedit, atau
-menolak komentar, commit, kode, suntingan wiki, masalah, dan kontribusi lainnya
+menolak komentar, commit, kode, suntingan wiki, isu, dan kontribusi lainnya
 yang tidak sesuai dengan Kode Etik ini, atau untuk melarang sementara
-atau secara permanen kontributor untuk perilaku lain yang mereka anggap tidak tepat, mengancam, menyinggung, atau berbahaya.
+atau secara permanen, berkontribusi dalam hal perilaku lain yang di anggap tidak pantas, mengancam, menyinggung, atau berbahaya.
 
-## Cakupan
+## Lingkup
 
 Kode Etik ini berlaku baik di dalam proyek maupun di ruang publik
 ketika seseorang mewakili proyek atau komunitasnya. Contoh dari
-mewakili sebuah proyek atau komunitas termasuk menggunakan alamat email resmi proyek, posting melalui akun media sosial resmi, atau bertindak sebagai orang yand ditunjuk menjadi perwakilan di acara online atau offline. Representasi proyek mungkin selanjutnya didefinisikan dan diklarifikasi oleh pengelola proyek.
+mewakili sebuah proyek atau komunitas termasuk dalam menggunakan alamat email resmi proyek, posting melalui akun media sosial resmi, atau bertindak sebagai orang yand ditunjuk menjadi perwakilan di acara online atau offline. Representasi proyek mungkin selanjutnya didefinisikan dan diklarifikasi oleh pengelola proyek.
 
 ## Penegakan
 
-Kejdian perilaku kasar, pelecehan, atau tidak dapat diterima yang terjadi
+Kejadian perilaku kasar, pelecehan, atau tidak dapat diterima yang terjadi
 dapat dilaporkan kepada tim inti proyek di [INSERT EMAIL ADDRESS]. Semua keluhan
-akan ditinjau dan diselidiki dan akan menghasilkan tanggapan yang dianggap perlu 
-dan sesuai dengan keadaan. Tim inti proyek berkewajiban menjaga kerahasiaan pelapor berkenaan dengan pelapor suatu insiden. 
-Rincian lebih lanjut tentang kebijakan penegakan khusus akan dipublikasikan secara terpisah.
+akan ditinjau, diselidiki dan akan menghasilkan tanggapan yang dianggap perlu 
+dan sesuai dengan keadaan. Tim inti proyek berkewajiban menjaga kerahasiaan pelapor yang berkenaan dengan laporan suatu insiden. Rincian lebih lanjut tentang kebijakan penegakan khusus akan dipublikasikan secara terpisah.
 
 Pengelola proyek yang tidak mengikuti atau melaksanakan Kode Etik dengan itikad
 baik mungkin akan menghadapi dampak sementara atau permanen seperti yang ditentukan
@@ -62,6 +59,6 @@ oleh para anggota lain dari pimpinan proyek.
 ## Atribut
 
 Kode Etik ini diadaptasi dari [Contributor Covenant][homepage], versi 1.4,
-tersedia di https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+tersedia di [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html][version]
 
 [homepage]: https://www.contributor-covenant.org


### PR DESCRIPTION
I think:

## Janji Kami => Ikrar Kami

**Ikrar** = Pledge. Is more suit for the "Pledge" word is like "swear to something or like real promise" and more meaning than,
**Janji** = Promise (promising to something).

> _In_ the interest of _fostering_ an open and welcoming environment,

In = **Dalam** is more suit than **Sesuai**. Because we are "in side" the open-source project. and
foresting (grow or growning) = **menumbuhkan**. I think, open-source is like a tree. They / we grow together by "making (_membuat_)" things (fruit).

## Standar Kami

I think the first and second points are better to have the same correlation with the original attachment, which is an **example** of behavior.

Others only add/correct several words and letters, and correction ".MD" (bare-url).