### PR TITLE
ENH: add PyMC4 to adopters

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -155,6 +155,7 @@ Pressbooks, https://github.com/pressbooks/pressbooks
 ProcessIterator, https://github.com/console-helpers/process-iterator
 PyBBIO, https://github.com/graycatlabs/PyBBIO
 PyMC3, https://github.com/pymc-devs/pymc3
+PyMC4, https://github.com/pymc-devs/pymc4
 Python-dwca-reader, https://github.com/BelgianBiodiversityPlatform/python-dwca-reader
 QA-Tools, https://github.com/qa-tools/qa-tools
 Quack Lang, https://github.com/quack/quack

--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -207,7 +207,8 @@ The PHP League OAuth 2.0 Server, https://github.com/thephpleague/oauth2-server
 Tide, https://github.com/wptide/wptide
 TinyMCE, https://www.tinymce.com/docs/advanced/contributing-to-open-source/
 Tmuxinator, https://github.com/tmuxinator/tmuxinator
-Travis CI, https://travis-ci.community/t/code-of-conduct/64Turbolinks, https://github.com/turbolinks/turbolinks
+Travis CI, https://travis-ci.community/t/code-of-conduct/64
+Turbolinks, https://github.com/turbolinks/turbolinks
 Twisted, https://github.com/twisted/twisted
 tbox, https://github.com/tboox/tbox
 UXP, https://github.com/MoonchildProductions/UXP


### PR DESCRIPTION
Adding PyMC4 to the list of adopters. Our code of conduct is [here](https://github.com/pymc-devs/pymc4/blob/master/CODE_OF_CONDUCT.md) if you'd like to confirm.