### PR TITLE
Fix amibguous sentence in Scope-section.

### DIFF
--- a/content/version/1/4/code-of-conduct.md
+++ b/content/version/1/4/code-of-conduct.md
@@ -50,12 +50,12 @@ threatening, offensive, or harmful.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+This Code of Conduct applies within all project spaces, and also applies when an
+individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
 
 ## Enforcement
 

--- a/content/version/1/4/code-of-conduct.md
+++ b/content/version/1/4/code-of-conduct.md
@@ -50,8 +50,8 @@ threatening, offensive, or harmful.
 
 ## Scope
 
-This Code of Conduct applies within all project spaces, and also applies when an
-individual is representing the project or its community in public spaces.
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
 Examples of representing a project or community include using an official
 project e-mail address, posting via an official social media account, or acting
 as an appointed representative at an online or offline event. Representation of


### PR DESCRIPTION
The first sentence of the Scope-section didn't clearly indicate that the `when an individual is representing the project or its community`-part only applies to the second half of the sentence (`in public spaces`) and not the whole sentence.
This PR therefore changes the layout of the sentence to remove all ambiguity; as discussed here: https://github.com/ContributorCovenant/contributor_covenant/issues/659