### PR TITLE
Add Algorithm Archive to adopters.csv.

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -3,6 +3,7 @@
 AASM, https://github.com/aasm/aasm
 Active Admin, https://github.com/activeadmin/activeadmin
 ActsAsTextcaptcha, https://github.com/matthutchinson/acts_as_textcaptcha
+Algorithm Archive, https://github.com/algorithm-archivists/algorithm-archive
 Algorrent, https://github.com/algorrent/algorrent
 All Algorithms, https://github.com/abranhe/algorithms
 Android IMSI-Catcher Detector, https://github.com/CellularPrivacy/Android-IMSI-Catcher-Detector


### PR DESCRIPTION
You can find the Algorithm Archive here: <https://github.com/algorithm-archivists/algorithm-archive>
A modification of the Contributor Covenant got added as our CoC with the following PR: <https://github.com/algorithm-archivists/algorithm-archive/pull/597>