### PR TITLE
Suggest README badge

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -49,7 +49,10 @@ You may want to add language similar to this to introduce your code of conduct:
 > Conduct. By participating in this project you agree to abide by its
 > terms.
 
-You may also use the permalinks given above to reference from your project home page.
+You may also use the permalinks given above to reference from your project home page. If you are using a markdown README file, you may want to add a badge like this one ![Contributor Covenant Badge](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg) using the code below.
+```
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](code-of-conduct.md)
+```
 
 <strong class="important">Important!</strong> You must add a contact method to the placeholder in the document so that people know how to report violations.
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -49,12 +49,14 @@ You may want to add language similar to this to introduce your code of conduct:
 > Conduct. By participating in this project you agree to abide by its
 > terms.
 
-You may also use the permalinks given above to reference from your project home page. If you are using a markdown README file, you may want to add a badge like this one ![Contributor Covenant Badge](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg) using the code below.
+You may also use the permalinks given above to reference from your project home page. 
+
+<strong class="important">Important!</strong> You must add a contact method to the placeholder in the document so that people know how to report violations.
+
+If you are using a markdown README file in your source code repository, you may want to add a badge like this one ![Contributor Covenant Badge](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg) using the code below.
 ```
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](code-of-conduct.md)
 ```
-
-<strong class="important">Important!</strong> You must add a contact method to the placeholder in the document so that people know how to report violations.
 
 *The Contributor Covenant is released under the [Creative Commons Attribution 4.0 International Public License](https://github.com/ContributorCovenant/contributor_covenant/blob/release/LICENSE.md), which requires that attribution be included.*
 


### PR DESCRIPTION
Many projects on Github use README badges to provide important information about their projects at one glance. This edit suggests code for a README badge that communicates adoption of the Contributor Covenant.