### PR TITLE
Update GNU Guix home page and distribution name

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -78,7 +78,7 @@ Git for Windows, https://github.com/git-for-windows
 GitLab, https://gitlab.com/gitlab-org/gitlab-ce/
 Giveth, https://wiki.giveth.io/policy/codeofconduct/
 GNSS-SDR, https://github.com/gnss-sdr/gnss-sdr
-GNU Guix and GuixSD, https://www.gnu.org/software/guix/
+GNU Guix and Guix System, https://guix.gnu.org
 Golang, https://golang.org/conduct
 Golden Cobra, https://github.com/ikuseiGmbH/Goldencobra
 Google, https://opensource.google.com/docs/releasing/template/CODE_OF_CONDUCT/


### PR DESCRIPTION
I have no idea what's going on [here](https://github.com/ContributorCovenant/contributor_covenant/pull/518#commitcomment-34325734) but thanks for making me notice outdated stuff, I guess,  @siridech28.