### PR TITLE
Fixed wrong grammar and spelling, made grammar within list more consistent

### DIFF
--- a/content/version/1/4/code-of-conduct.de.md
+++ b/content/version/1/4/code-of-conduct.de.md
@@ -14,16 +14,16 @@ Im Interesse der Förderung eines offenen und einladenden Umfeldes wollen wir un
 Beispiele für Verhaltensweisen, welche dazu beitragen ein positives Umfeld zu erzeugen, beinhalten:
 
 * Die Verwendung von einladenden und einbindenden Formulierungen
-* Abweichenden Ansichten und Erfahrungen wird Respekt entgegengebracht
-* Konstruktive Kritik wird höflich entgegengenommen
-* Fokussierung auf das, was das Beste ist für die Gemeinschaft
-* Verständnis zeigen gegenüber anderen Mitgliedern der Gemeinschaft
+* Respektieren von abweichenden Ansichten und Erfahrungen
+* Höfliches Entgegennehmen konstruktiver Kritik
+* Fokussierung auf das Beste für die Gemeinschaft
+* Verständnis gegenüber anderen Mitgliedern der Gemeinschaft
 
 Beispiele für nicht akzeptables Verhalten beinhalten:
 
 * Die Verwendung sexualisierter Sprache, Bilder oder Symbolik sowie unerwünschte Versuche sexueller Anbahnung
 * Beleidigende / abwertende Kommentare, persönliche oder politische Angriffe, Nutzung des Internets für unbilliges Verhalten
-* Öffentliche oder private Belästigungen
+* Öffentliche oder private Belästigung
 * Das Veröffentlichen von privaten Informationen Anderer, wie zum Beispiel physische oder elektronische Adressen, ohne deren ausdrückliche Erlaubnis
 * Anderes Verhalten, welches in einem professionellen Umfeld begründet als unangemessen betrachtet werden kann 
 
@@ -39,7 +39,7 @@ Dieser Verhaltenskodex gilt sowohl innerhalb des Projektbereichs als auch in öf
 
 ## Umsetzung
 
-Fälle von missbräuchlichem, belästigendem oder anderweitig nicht akzeptablem Verhalten können dem Projektteam unter [EMAIL ADRESSE EINFÜGEN] gemeldet werden. Alle Beschwerden werden geprüft und untersucht und werden zu einer Antwort führen, die angesichts der Umstände für notwendig und angemessen gehalten wird. Das Projektteam ist verpflichtet, über diejenigen, die Vorfälle gemeldet haben, Verschwiegenheit zu wahren. Weitere Einzelheiten zu speziellen Umsetzungsgrundsätzen können gesondert mitgeteilt werden.
+Fälle von missbräuchlichem, belästigendem oder anderweitig nicht akzeptablem Verhalten können dem Projektteam unter [E-MAIL-ADRESSE EINFÜGEN] gemeldet werden. Alle Beschwerden werden geprüft und untersucht und werden zu einer Antwort führen, die angesichts der Umstände für notwendig und angemessen gehalten wird. Das Projektteam ist verpflichtet, über diejenigen, die Vorfälle gemeldet haben, Verschwiegenheit zu wahren. Weitere Einzelheiten zu speziellen Umsetzungsgrundsätzen können gesondert mitgeteilt werden.
 
 Projektverantwortliche, welche den Verhaltenskodex nicht befolgen, oder nicht nach bestem Wissen und Glauben für dessen Einhaltung sorgen, können sich vorübergehenden oder dauerhaften Auswirkungen gegenübersehen, die durch andere Mitglieder der Projektleitung bestimmt wurden.
 


### PR DESCRIPTION
["Email" is a coating for metal surfaces.](https://www.duden.de/rechtschreibung/Email) An "E-Mail" is an electronic letter. Also, there are no blanks within compound words. 

Made the list of standards consistently not use passive forms.