### PR TITLE
Added ACM-W NITK to adopters.csv

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -1,6 +1,7 @@
 .NET Foundation, http://www.dotnetfoundation.org/code-of-conduct
 24 Pull Requests, https://github.com/24pullrequests/24pullrequests
 AASM, https://github.com/aasm/aasm
+ACM-W NITK, https://github.com/acm-w-nitk/acm-w-nitk.github.io
 Active Admin, https://github.com/activeadmin/activeadmin
 ActsAsTextcaptcha, https://github.com/matthutchinson/acts_as_textcaptcha
 Algorithm Archive, https://github.com/algorithm-archivists/algorithm-archive


### PR DESCRIPTION
ACM-W NITK is a chapter in National Institute of Technology, Karnataka, India focused on empowering and upskilling women in the professional domain. We would like to adopt the Contributor Covenant in our organization's repository.