### PR TITLE
Change disability term by functional diversity

### DIFF
--- a/content/version/1/0/0/code-of-conduct.md
+++ b/content/version/1/0/0/code-of-conduct.md
@@ -7,7 +7,7 @@ aliases = ["/version/1/0/0"]
 
 As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
 
-We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, functional diversity, personal appearance, body size, race, ethnicity, age, or religion.
 
 Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
 

--- a/content/version/1/1/0/code-of-conduct.md
+++ b/content/version/1/1/0/code-of-conduct.md
@@ -7,7 +7,7 @@ aliases = ["/version/1/1/0"]
 
 As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
 
-We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, functional diversity, personal appearance, body size, race, ethnicity, age, or religion.
 
 Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
 

--- a/content/version/1/2/0/code-of-conduct.md
+++ b/content/version/1/2/0/code-of-conduct.md
@@ -7,7 +7,7 @@ aliases = ["/version/1/2/0"]
 
 As contributors and maintainers of this project, and in the interest of fostering an open and welcoming community, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
 
-We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or nationality.
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, functional diversity, personal appearance, body size, race, ethnicity, age, religion, or nationality.
 
 Examples of unacceptable behavior by participants include:
 

--- a/content/version/1/3/0/code-of-conduct.es.md
+++ b/content/version/1/3/0/code-of-conduct.es.md
@@ -7,7 +7,7 @@ aliases = ["/version/1/3/0/es/"]
 
 Como contribuyentes y administradores de este proyecto, y en el interés de fomentar una comunidad abierta y acogedora, nos comprometemos a respetar a todas las personas que colaboran reportando errores, solicitando nuevas funcionalidades, actualizando documentación, generando *pull requests*, entre otras actividades.
 
-Nos comprometemos a hacer que la participación en este proyecto sea una experiencia libre de acoso para todos, independientemente de su experiencia, género, identidad y expresión de género, orientación sexual, discapacidad, apariencia física, dimensión corporal, raza, etnia, edad, religión o nacionalidad.
+Nos comprometemos a hacer que la participación en este proyecto sea una experiencia libre de acoso para todos, independientemente de su experiencia, género, identidad y expresión de género, orientación sexual, diversidad funcional, apariencia física, dimensión corporal, raza, etnia, edad, religión o nacionalidad.
 
 Ejemplos de comportamiento inaceptable por participantes son:
 

--- a/content/version/1/3/0/code-of-conduct.md
+++ b/content/version/1/3/0/code-of-conduct.md
@@ -12,7 +12,7 @@ documentation, submitting pull requests or patches, and other activities.
 
 We are committed to making participation in this project a harassment-free
 experience for everyone, regardless of level of experience, gender, gender
-identity and expression, sexual orientation, disability, personal appearance,
+identity and expression, sexual orientation, functional diversity, personal appearance,
 body size, race, ethnicity, age, religion, or nationality.
 
 Examples of unacceptable behavior by participants include:

--- a/content/version/1/4/code-of-conduct.es.md
+++ b/content/version/1/4/code-of-conduct.es.md
@@ -7,7 +7,7 @@ aliases = ["/version/1/4/es"]
 
 ## Nuestro compromiso
 
-En el interés de fomentar una comunidad abierta y acogedora, nosotros como contribuyentes y administradores nos comprometemos a hacer de la participación en nuestro proyecto y nuestra comunidad una experiencia libre de acoso para todos, independientemente de la edad, dimensión corporal, discapacidad, etnia, identidad y expresión de género, nivel de experiencia, nacionalidad, apariencia física, raza, religión, identidad u orientación sexual. 
+En el interés de fomentar una comunidad abierta y acogedora, nosotros como contribuyentes y administradores nos comprometemos a hacer de la participación en nuestro proyecto y nuestra comunidad una experiencia libre de acoso para todos, independientemente de la edad, dimensión corporal, diversidad funcional, etnia, identidad y expresión de género, nivel de experiencia, nacionalidad, apariencia física, raza, religión, identidad u orientación sexual.
 
 ## Nuestros estándares
 
@@ -29,19 +29,19 @@ Ejemplos de comportamiento inaceptable por participantes:
 
 ## Nuestras responsabilidades
 
-Los administradores del proyecto son responsables de clarificar los estándares de comportamiento aceptable y se espera que tomen medidas correctivas y apropiadas en respuesta a situaciones de conducta inaceptable. 
+Los administradores del proyecto son responsables de clarificar los estándares de comportamiento aceptable y se espera que tomen medidas correctivas y apropiadas en respuesta a situaciones de conducta inaceptable.
 
 Los administradores del proyecto tienen el derecho y la responsabilidad de eliminar, editar o rechazar comentarios, *commits*, código, ediciones de documentación, *issues*, y otras contribuciones que no estén alineadas con este Código de Conducta, o de prohibir temporal o permanentemente a cualquier colaborador cuyo comportamiento sea inapropiado, amenazante, ofensivo o perjudicial.
 
 ## Alcance
 
 Este código de conducta aplica tanto a espacios del proyecto como a espacios públicos donde un individuo esté en representación del proyecto o comunidad. Ejemplos de esto incluye el uso de la cuenta oficial de correo electrónico, publicaciones a través de las redes sociales oficiales, o presentaciones con personas designadas en eventos *online* u *offline*. La representación del proyecto puede ser clarificada explicitamente por los administradores del proyecto.
- 
+
 ## Aplicación
 
 Ejemplos de abuso, acoso u otro tipo de comportamiento inaceptable puede ser reportado al equipo del proyecto en [INSERTE CORREO AQUÍ]. Todas las quejas serán revisadas e investigadas, generando un resultado apropiado a las circunstancias. El equipo del proyecto está obligado a mantener confidencialidad de la persona que reportó el incidente. Detalles específicos acerca de las políticas de aplicación pueden ser publicadas por separado.
 
-Administradores que no sigan o que no hagan cumplir este Código de Conducta pueden ser eliminados de forma temporal o permanente del equipo administrador. 
+Administradores que no sigan o que no hagan cumplir este Código de Conducta pueden ser eliminados de forma temporal o permanente del equipo administrador.
 
 ## Atribución
 

--- a/content/version/1/4/code-of-conduct.md
+++ b/content/version/1/4/code-of-conduct.md
@@ -10,7 +10,7 @@ aliases = ["/version/1/4"]
 In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to make participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
+size, functional diversity, ethnicity, sex characteristics, gender identity and expression,
 level of experience, education, socio-economic status, nationality, personal
 appearance, race, religion, or sexual identity and orientation.
 


### PR DESCRIPTION
This pull request suggests changing the term `disability` by `functional diversity`. `Functional diversity` was proposed as a new term in the struggle for dignity in the diversity of the human being on the Independent Living Forum (Spain) - May 2005 ([link to the document](http://enil.eu/wp-content/uploads/2012/07/Functional-diversity-a-new-term-in-the-struggle-for-dignity-in-the-diversity-of-the-human-being_2005.pdf)).

More info about the term is available on its Wikipedia page: https://en.wikipedia.org/wiki/Functional_diversity_(disability).

It has been only changed for `en` and `es` languages, but it should be changed in other languages as well 😊 