### PR TITLE
Add Node.js and OpenJS Foundation

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -147,12 +147,14 @@ NColony, https://github.com/moshez/ncolony
 Neos, https://www.neos.io/
 Nerd Fonts, https://github.com/ryanoasis/nerd-fonts
 Nodejs Africa, https://nodejs.africa/
+Node.js, https://github.com/nodejs
 nteract, http://nteract.io/
 OAPI ShieldsUp, https://github.com/oapi/shieldsup
 Onnx-go, https://github.com/owulveryck/onnx-go
 Open WebRTC Toolkit, https://github.com/open-webrtc-toolkit
 OpenDominion, https://github.com/WaveHack/OpenDominion
 OpenDroneMap, https://github.com/OpenDroneMap/OpenDroneMap
+OpenJS Foundation, https://github.com/openjs-foundation/
 OpenProject, https://www.openproject.org/
 Operable, https://github.com/operable/
 ORGENIC UI, https://github.com/orgenic/orgenic-ui


### PR DESCRIPTION
References:

- Node.js Code of Conduct: https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md
- OpenJS Foundation Code of Conduct: https://github.com/openjs-foundation/cross-project-council/blob/master/CODE_OF_CONDUCT.md

Realized that I'd just assumed Node.js was on this list rather than actually checking. Also, many if not all OpenJS Foundation projects use this code of conduct.