### PR TITLE
Update front page links

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -17,9 +17,9 @@ Adopting the Contributor Covenant can be one way to express and codify these val
 
 You can view and download the latest version of the Contributor Covenant here:
 
-- [English (Markdown version)]({{< ref "/version/2/0/code-of-conduct.md" "markdown" >}})
-- [English (HTML version)]({{< ref "/version/2/0/code-of-conduct.md" >}})
-- [English (text version)]({{< ref "/version/2/0/code-of-conduct.md" "plaintext" >}})
+- [English (Markdown version)]({{< ref "/version/2/0/code_of_conduct.md" "markdown" >}})
+- [English (HTML version)]({{< ref "/version/2/0/code_of_conduct.md" >}})
+- [English (text version)]({{< ref "/version/2/0/code_of_conduct.md" "plaintext" >}})
 
 For translations of the Contributor Covenant, please see our [translations page]({{< ref "translations.md" >}}).
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -13,13 +13,13 @@ One way to begin addressing this problem is to be overt in our openness, welcomi
 
 Adopting the Contributor Covenant can be one way to express and codify these values and signal your intention to make your open source community welcoming, diverse, and inclusive.
 
-## Contributor Covenant v1.4.1
+## Contributor Covenant v2.0
 
 You can view and download the latest version of the Contributor Covenant here:
 
-- [English (Markdown version)]({{< ref "/version/1/4/code-of-conduct.md" "markdown" >}})
-- [English (HTML version)]({{< ref "/version/1/4/code-of-conduct.md" >}})
-- [English (text version)]({{< ref "/version/1/4/code-of-conduct.md" "plaintext" >}})
+- [English (Markdown version)]({{< ref "/version/2/0/code-of-conduct.md" "markdown" >}})
+- [English (HTML version)]({{< ref "/version/2/0/code-of-conduct.md" >}})
+- [English (text version)]({{< ref "/version/2/0/code-of-conduct.md" "plaintext" >}})
 
 For translations of the Contributor Covenant, please see our [translations page]({{< ref "translations.md" >}}).
 

--- a/layouts/shortcodes/previous-versions.html
+++ b/layouts/shortcodes/previous-versions.html
@@ -2,4 +2,5 @@ Previous versions are available here:
 <a href="{{ ref $.Page "/version/1/0/0/code-of-conduct.md" }}">1.0</a>,
 <a href="{{ ref $.Page "/version/1/1/0/code-of-conduct.md" }}">1.1</a>,
 <a href="{{ ref $.Page "/version/1/2/0/code-of-conduct.md" }}">1.2</a>,
-and <a href="{{ ref $.Page "/version/1/3/0/code-of-conduct.md" }}">1.3</a>.
+<a href="{{ ref $.Page "/version/1/3/0/code-of-conduct.md" }}">1.3</a>,
+and <a href="{{ ref $.Page "/version/1/4/code-of-conduct.md" }}">1.4</a>.


### PR DESCRIPTION
This pull request updates the links to the **latest** version of the Contributor Covenant so that they point to v2.0, similar to the updated link in the web page header.

Additionally, because v1.4.0 is not the latest version anymore, a link to the 1.4 Contributor Covenant is added to the previous-versions layout block, so that it is easy to access to the older version from the home page.