### PR TITLE
Provide CoC catalan version

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -58,7 +58,7 @@ languageName = "Bosnian"
 languageCode = "bs"
 
 [Languages.ca]
-languageName = "Catalan"
+languageName = "Català"
 languageCode = "ca"
 
 [Languages.de]

--- a/config.toml
+++ b/config.toml
@@ -57,6 +57,10 @@ languageCode = "bn"
 languageName = "Bosnian"
 languageCode = "bs"
 
+[Languages.ca]
+languageName = "Catalan"
+languageCode = "ca"
+
 [Languages.de]
 languageName = "Deutsch"
 languageCode = "de"

--- a/content/version/2/0/code_of_conduct.ca.md
+++ b/content/version/2/0/code_of_conduct.ca.md
@@ -21,7 +21,7 @@ Exemples de comportament que contribueixen a crear un ambient positiu per a la n
 * Acceptar la responsabilitat i disculpar-se davant els que es vegin afectats pels nostres errors, aprenent de l'experiència
 * Centrar-se en el que sigui millor no sols per a nosaltres com a individus, sinó per a la comunitat en general
 
-Exemples de comportament inacceptable:
+Exemples de comportament inapropiat:
 
 * L'ús de llenguatge o imatges sexualitzades, i atencions o aproximacions sexuals de qualsevol tipus
 * Comentaris provocadors (_trolling_), insultants o despectius, i atacs personals o polítics
@@ -41,7 +41,7 @@ Aquest Codi de Conducta és d'aplicació dins de tots els espais de la comunitat
 
 ## Aplicació
 
-Casos de comportament abusiu, assetjador o de qualsevol altre caire inacceptable podran ser reportats als administradors de la comunitat responsables del compliment a través de [INSERIR MÈTODE DE CONTACTE]. Totes les queixes seran investigades i avaluades de forma justa i puntual.
+Casos de comportament abusiu, assetjador o de qualsevol altre caire inapropiat podran ser reportats als administradors de la comunitat responsables del compliment a través de [INSERIR MÈTODE DE CONTACTE]. Totes les queixes seran investigades i avaluades de forma justa i puntual.
 
 Tots els administradors de la comunitat estan obligats a respectar la privacitat i la seguretat de qui reporti incidents.
 
@@ -53,7 +53,7 @@ Els administradors de la comunitat seguiran aquestes Pautes d'Impacte en la Comu
 
 **Impacte en la Comunitat**: L'ús de llenguatge inapropiat o qualsevol altre comportament considerat no professional o no acollidor en la comunitat.
 
-**Conseqüència**: Un avís escrit i privat per part dels administradors de la comunitat, proporcionant claredat al voltant de la naturalesa d'aquest incompliment i una explicació de per què el comportament és inacceptable. Una disculpa pública podria ser sol·licitada.
+**Conseqüència**: Un avís escrit i privat per part dels administradors de la comunitat, proporcionant claredat al voltant de la naturalesa d'aquest incompliment i una explicació de per què el comportament és inapropiat. Es podria sol·licitar una disculpa pública.
 
 ### 2. Avís
 

--- a/content/version/2/0/code_of_conduct.ca.md
+++ b/content/version/2/0/code_of_conduct.ca.md
@@ -37,7 +37,7 @@ Els administradors de la comunitat tindran el dret i la responsabilitat d'elimin
 
 ## Abast
 
-Aquest Codi de Conducta aplica dins de tots els espais de la comunitat, i també aplica quan un individu representa oficialment a la comunitat en espais públics. Exemples de representació inclouen l'ús del compte oficial de correu electrònic, publicacions a través de les xarxes socials oficials, o les persones designades com a representants en esdeveniments en línia o en viu.
+Aquest Codi de Conducta és d'aplicació dins de tots els espais de la comunitat, i també aplica quan un individu representa oficialment a la comunitat en espais públics. Exemples de representació inclouen l'ús del compte oficial de correu electrònic, publicacions a través de les xarxes socials oficials, o actuar com a representant designat en esdeveniments en línia o no.
 
 ## Aplicació
 

--- a/content/version/2/0/code_of_conduct.ca.md
+++ b/content/version/2/0/code_of_conduct.ca.md
@@ -31,7 +31,7 @@ Exemples de comportament inacceptable:
 
 ## Aplicació de les responsabilitats
 
-Els administradors de la comunitat són responsables d'aclarir i fer complir els nostres estàndards de comportament acceptable i prendran accions apropiades i correctives de manera justa en resposta a qualsevol comportament que considerin inapropiat, amenaçador, ofensiu o nociu.
+Els administradors de la comunitat són responsables d'aclarir i fer complir els nostres estàndards de comportament acceptable i prendran accions correctives justes i apropiades en resposta a qualsevol comportament que considerin inapropiat, amenaçador, ofensiu o nociu.
 
 Els administradors de la comunitat tindran el dret i la responsabilitat d'eliminar, editar o rebutjar comentaris, _commits_, codi, edicions de pàgines de wiki, _issues_ i altres contribucions que no s'alineïn amb aquest Codi de Conducta, i comunicaran les raons de les seves decisions de moderació quan sigui apropiat.
 

--- a/content/version/2/0/code_of_conduct.ca.md
+++ b/content/version/2/0/code_of_conduct.ca.md
@@ -24,7 +24,7 @@ Exemples de comportament que contribueixen a crear un ambient positiu per a la n
 Exemples de comportament inacceptable:
 
 * L'ús de llenguatge o imatges sexualitzades, i atencions o aproximacions sexuals de qualsevol tipus
-* Comentaris despectius (_trolling_), insultants o derogatoris, i atacs personals o polítics
+* Comentaris provocadors (_trolling_), insultants o despectius, i atacs personals o polítics
 * L'assetjament en públic o en privat
 * Publicar informació privada d'altres persones, com adreces físiques o de correu electrònic, sense el seu permís explícit
 * Altres conductes que puguin ser raonablement considerades com a inapropiades en un entorn professional

--- a/content/version/2/0/code_of_conduct.ca.md
+++ b/content/version/2/0/code_of_conduct.ca.md
@@ -7,7 +7,7 @@ aliases = ["/version/2/0/ca"]
 
 ## El nostre compromís
 
-Nosaltres, com a membres, col·laboradors i administradors ens comprometem a fer de la participació en la nostra comunitat una experiència lliure d'assetjament per a tothom, independentment de l'edat, dimensió corporal, discapacitat visible o invisible, etnicitat, característiques sexuals, identitat i expressió de gènere, nivell d'experiència, educació, nivell socioeconòmic, nacionalitat, aparença personal, raça, religió, identitat o orientació sexual.
+Nosaltres, com a membres, col·laboradors i administradors ens comprometem a fer de la participació en la nostra comunitat una experiència lliure d'assetjament per a tothom, independentment de l'edat, mida corporal, discapacitat visible o invisible, etnicitat, característiques sexuals, identitat i expressió de gènere, nivell d'experiència, educació, nivell socioeconòmic, nacionalitat, aparença personal, raça, religió, identitat o orientació sexual.
 
 Ens comprometem a actuar i interactuar de maneres que contribueixin a una comunitat oberta, acollidora, diversa, inclusiva i sana.
 

--- a/content/version/2/0/code_of_conduct.ca.md
+++ b/content/version/2/0/code_of_conduct.ca.md
@@ -7,7 +7,7 @@ aliases = ["/version/2/0/ca"]
 
 ## El nostre compromís
 
-Nosaltres, com a membres, col·laboradors i administradors ens comprometem a fer de la participació en la nostra comunitat una experiència lliure d'assetjament per a tothom, independentment de l'edat, mida corporal, discapacitat visible o invisible, etnicitat, característiques sexuals, identitat i expressió de gènere, nivell d'experiència, educació, nivell socioeconòmic, nacionalitat, aparença personal, raça, religió, identitat o orientació sexual.
+Nosaltres, com a membres, col·laboradors i administradors ens comprometem a fer de la participació en la nostra comunitat una experiència lliure d'assetjament per a tothom, independentment de l'edat, mida corporal, discapacitat visible o invisible, etnicitat, característiques sexuals, identitat i expressió de gènere, nivell d'experiència, educació, nivell socioeconòmic, nacionalitat, aparença personal, raça, religió, o identitat i orientació sexual.
 
 Ens comprometem a actuar i interactuar de maneres que contribueixin a una comunitat oberta, acollidora, diversa, inclusiva i sana.
 

--- a/content/version/2/0/code_of_conduct.ca.md
+++ b/content/version/2/0/code_of_conduct.ca.md
@@ -51,27 +51,27 @@ Els administradors de la comunitat seguiran aquestes Pautes d'Impacte en la Comu
 
 ### 1. Correcció
 
-*Impacte en la Comunitat*: L'ús de llenguatge inapropiat o qualsevol altre comportament considerat no professional o no acollidor en la comunitat.
+**Impacte en la Comunitat**: L'ús de llenguatge inapropiat o qualsevol altre comportament considerat no professional o no acollidor en la comunitat.
 
-*Conseqüència**: Un avís escrit i privat per part dels administradors de la comunitat, proporcionant claredat al voltant de la naturalesa d'aquest incompliment i una explicació de per què el comportament és inacceptable. Una disculpa pública podria ser sol·licitada.
+**Conseqüència**: Un avís escrit i privat per part dels administradors de la comunitat, proporcionant claredat al voltant de la naturalesa d'aquest incompliment i una explicació de per què el comportament és inacceptable. Una disculpa pública podria ser sol·licitada.
 
 ### 2. Avís
 
-*Impacte en la Comunitat*: Un incompliment causat per un únic incident o per una cadena d'accions.
+**Impacte en la Comunitat**: Un incompliment causat per un únic incident o per una cadena d'accions.
 
-*Conseqüència**: Un avís amb conseqüències per comportament prolongat. No s'interactua amb les persones involucrades, incloent interacció no sol·licitada amb els qui es troben aplicant el Codi de Conducta, per un període especificat de temps. Això inclou evitar les interaccions en espais de la comunitat, així com a través dels canals externs com les xarxes socials. Incomplir aquests termes pot conduir a una expulsió temporal o permanent.
+**Conseqüència**: Un avís amb conseqüències per comportament prolongat. No s'interactua amb les persones involucrades, incloent interacció no sol·licitada amb els qui es troben aplicant el Codi de Conducta, per un període especificat de temps. Això inclou evitar les interaccions en espais de la comunitat, així com a través dels canals externs com les xarxes socials. Incomplir aquests termes pot conduir a una expulsió temporal o permanent.
 
 ### 3. Expulsió temporal
 
-*Impacte en la Comunitat*: Una sèrie d'incompliments dels estàndards de la comunitat, incloent comportament inapropiat continu.
+**Impacte en la Comunitat**: Una sèrie d'incompliments dels estàndards de la comunitat, incloent comportament inapropiat continu.
 
-*Conseqüència**: Una restricció (__ban__) temporal de qualsevol forma d'interacció o comunicació pública amb la comunitat durant un interval de temps especificat. No es permet interactuar de manera pública o privada amb les persones involucrades, incloent interaccions no sol·licitades amb els qui es troben aplicant el Codi de Conducta durant aquest període. Incomplir aquests termes pot conduir a una expulsió permanent.
+**Conseqüència**: Una restricció (__ban__) temporal de qualsevol forma d'interacció o comunicació pública amb la comunitat durant un interval de temps especificat. No es permet interactuar de manera pública o privada amb les persones involucrades, incloent interaccions no sol·licitades amb els qui es troben aplicant el Codi de Conducta durant aquest període. Incomplir aquests termes pot conduir a una expulsió permanent.
 
 ### 4. Expulsió permanent
 
-*Impacte en la Comunitat*: Demostrar un patró sistemàtic d'incompliments dels estàndards de la comunitat, incloent conductes inapropiades prolongades en el temps, assetjament d'individus, agressions o menyspreu a grups d'individus.
+**Impacte en la Comunitat**: Demostrar un patró sistemàtic d'incompliments dels estàndards de la comunitat, incloent conductes inapropiades prolongades en el temps, assetjament d'individus, agressions o menyspreu a grups d'individus.
 
-*Conseqüència**: Una restricció (__ban__) permanent de qualsevol forma d'interacció pública amb la comunitat del projecte.
+**Conseqüència**: Una restricció (__ban__) permanent de qualsevol forma d'interacció pública amb la comunitat del projecte.
 
 ## Atribució
 

--- a/content/version/2/0/code_of_conduct.ca.md
+++ b/content/version/2/0/code_of_conduct.ca.md
@@ -63,7 +63,7 @@ Els administradors de la comunitat seguiran aquestes Pautes d'Impacte en la Comu
 
 ### 3. Expulsió temporal
 
-**Impacte en la Comunitat**: Una sèrie d'incompliments dels estàndards de la comunitat, incloent comportament inapropiat continu.
+**Impacte en la Comunitat**: Una sèrie d'incompliments dels estàndards de la comunitat, incloent comportament inapropiat continuat.
 
 **Conseqüència**: Una restricció (__ban__) temporal de qualsevol forma d'interacció o comunicació pública amb la comunitat durant un interval de temps especificat. No es permet interactuar de manera pública o privada amb les persones involucrades, incloent interaccions no sol·licitades amb els qui es troben aplicant el Codi de Conducta durant aquest període. Incomplir aquests termes pot conduir a una expulsió permanent.
 

--- a/content/version/2/0/code_of_conduct.ca.md
+++ b/content/version/2/0/code_of_conduct.ca.md
@@ -1,0 +1,84 @@
++++
+version = "2.0"
+aliases = ["/version/2/0/ca"]
++++
+
+# Codi de Conducta acordat pels Col·laboradors
+
+## El nostre compromís
+
+Nosaltres, com a membres, col·laboradors i administradors ens comprometem a fer de la participació en la nostra comunitat una experiència lliure d'assetjament per a tothom, independentment de l'edat, dimensió corporal, minusvalidesa visible o invisible, etnicitat, característiques sexuals, identitat i expressió de gènere, nivell d'experiència, educació, nivell socioeconòmic, nacionalitat, aparença personal, raça, religió, identitat o orientació sexual.
+
+Ens comprometem a actuar i interactuar de maneres que contribueixin a una comunitat oberta, acollidora, diversa, inclusiva i sana.
+
+## Els nostres estàndards
+
+Exemples de comportament que contribueixen a crear un ambient positiu per a la nostra comunitat:
+
+* Demostrar empatia i amabilitat davant d'altres persones
+* Respectar les diferents opinions, punts de vista i/o experiències
+* Donar i acceptar de forma elegant qualsevol crítica constructiva
+* Acceptar la responsabilitat i disculpar-se davant els que es vegin afectats pels nostres errors, aprenent de l'experiència
+* Centrar-se en el que sigui millor no sols per a nosaltres com a individus, sinó per a la comunitat en general
+
+Exemples de comportament inacceptable:
+
+* L'ús de llenguatge o imatges sexualitzades, i atencions o aproximacions sexuals de qualsevol tipus
+* Comentaris despectius (_trolling_), insultants o derogatoris, i atacs personals o polítics
+* L'assetjament en públic o en privat
+* Publicar informació privada d'altres persones, com adreces físiques o de correu electrònic, sense el seu permís explícit
+* Altres conductes que puguin ser raonablement considerades com a inapropiades en un entorn professional
+
+## Aplicació de les responsabilitats
+
+Els administradors de la comunitat són responsables d'aclarir i fer complir els nostres estàndards de comportament acceptable i prendran accions apropiades i correctives de manera justa en resposta a qualsevol comportament que considerin inapropiat, amenaçador, ofensiu o nociu.
+
+Els administradors de la comunitat tindran el dret i la responsabilitat d'eliminar, editar o rebutjar comentaris, _commits_, codi, edicions de pàgines de wiki, _issues_ i altres contribucions que no s'alineïn amb aquest Codi de Conducta, i comunicaran les raons de les seves decisions de moderació quan sigui apropiat.
+
+## Abast
+
+Aquest Codi de Conducta aplica dins de tots els espais de la comunitat, i també aplica quan un individu representa oficialment a la comunitat en espais públics. Exemples de representació inclouen l'ús del compte oficial de correu electrònic, publicacions a través de les xarxes socials oficials, o les persones designades com a representants en esdeveniments en línia o en viu.
+
+## Aplicació
+
+Casos de comportament abusiu, assetjador o de qualsevol altre caire inacceptable podran ser reportats als administradors de la comunitat responsables del compliment a través de [INSERIR MÈTODE DE CONTACTE]. Totes les queixes seran investigades i avaluades de forma justa i puntual.
+
+Tots els administradors de la comunitat estan obligats a respectar la privacitat i la seguretat de qui reporti incidents.
+
+## Directrius d'Aplicació
+
+Els administradors de la comunitat seguiran aquestes Pautes d'Impacte en la Comunitat per tal de determinar les conseqüències de qualsevol acció que jutgin com un incompliment d'aquest Codi de Conducta:
+
+### 1. Correcció
+
+*Impacte en la Comunitat*: L'ús de llenguatge inapropiat o qualsevol altre comportament considerat no professional o no acollidor en la comunitat.
+
+*Conseqüència**: Un avís escrit i privat per part dels administradors de la comunitat, proporcionant claredat al voltant de la naturalesa d'aquest incompliment i una explicació de per què el comportament és inacceptable. Una disculpa pública podria ser sol·licitada.
+
+### 2. Avís
+
+*Impacte en la Comunitat*: Un incompliment causat per un únic incident o per una cadena d'accions.
+
+*Conseqüència**: Un avís amb conseqüències per comportament prolongat. No s'interactua amb les persones involucrades, incloent interacció no sol·licitada amb els qui es troben aplicant el Codi de Conducta, per un període especificat de temps. Això inclou evitar les interaccions en espais de la comunitat, així com a través dels canals externs com les xarxes socials. Incomplir aquests termes pot conduir a una expulsió temporal o permanent.
+
+### 3. Expulsió temporal
+
+*Impacte en la Comunitat*: Una sèrie d'incompliments dels estàndards de la comunitat, incloent comportament inapropiat continu.
+
+*Conseqüència**: Una restricció (__ban__) temporal de qualsevol forma d'interacció o comunicació pública amb la comunitat durant un interval de temps especificat. No es permet interactuar de manera pública o privada amb les persones involucrades, incloent interaccions no sol·licitades amb els qui es troben aplicant el Codi de Conducta durant aquest període. Incomplir aquests termes pot conduir a una expulsió permanent.
+
+### 4. Expulsió permanent
+
+*Impacte en la Comunitat*: Demostrar un patró sistemàtic d'incompliments dels estàndards de la comunitat, incloent conductes inapropiades prolongades en el temps, assetjament d'individus, agressions o menyspreu a grups d'individus.
+
+*Conseqüència**: Una restricció (__ban__) permanent de qualsevol forma d'interacció pública amb la comunitat del projecte.
+
+## Atribució
+
+Aquest Codi de Conducta és una adaptació del [Contributor Covenant][homepage], versió 2.0, disponible a https://www.contributor-covenant.org/es/version/2/0/code_of_conduct.html
+
+Les Guies d'Impacte en la Comunitat estan inspirades en l'[escala d'aplicació del codi de conducta de Mozilla](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+Per a trobar resposta a les preguntes freqüents d'aquest codi de conducta pots consultar les FAQ a https://www.contributor-covenant.org/faq. Hi ha traduccions disponibles a https://www.contributor-covenant.org/translations

--- a/content/version/2/0/code_of_conduct.ca.md
+++ b/content/version/2/0/code_of_conduct.ca.md
@@ -16,7 +16,7 @@ Ens comprometem a actuar i interactuar de maneres que contribueixin a una comuni
 Exemples de comportament que contribueixen a crear un ambient positiu per a la nostra comunitat:
 
 * Demostrar empatia i amabilitat davant d'altres persones
-* Respectar les diferents opinions, punts de vista i/o experiències
+* Respectar les diferents opinions, punts de vista, i experiències
 * Donar i acceptar de forma elegant qualsevol crítica constructiva
 * Acceptar la responsabilitat i disculpar-se davant els que es vegin afectats pels nostres errors, aprenent de l'experiència
 * Centrar-se en el que sigui millor no sols per a nosaltres com a individus, sinó per a la comunitat en general

--- a/content/version/2/0/code_of_conduct.ca.md
+++ b/content/version/2/0/code_of_conduct.ca.md
@@ -7,7 +7,7 @@ aliases = ["/version/2/0/ca"]
 
 ## El nostre compromís
 
-Nosaltres, com a membres, col·laboradors i administradors ens comprometem a fer de la participació en la nostra comunitat una experiència lliure d'assetjament per a tothom, independentment de l'edat, dimensió corporal, minusvalidesa visible o invisible, etnicitat, característiques sexuals, identitat i expressió de gènere, nivell d'experiència, educació, nivell socioeconòmic, nacionalitat, aparença personal, raça, religió, identitat o orientació sexual.
+Nosaltres, com a membres, col·laboradors i administradors ens comprometem a fer de la participació en la nostra comunitat una experiència lliure d'assetjament per a tothom, independentment de l'edat, dimensió corporal, discapacitat visible o invisible, etnicitat, característiques sexuals, identitat i expressió de gènere, nivell d'experiència, educació, nivell socioeconòmic, nacionalitat, aparença personal, raça, religió, identitat o orientació sexual.
 
 Ens comprometem a actuar i interactuar de maneres que contribueixin a una comunitat oberta, acollidora, diversa, inclusiva i sana.
 


### PR DESCRIPTION
It provides an initial translation of the CoC using as a base the spanish translation.

Fix #738 Provide Catalan translation
