### PR TITLE
add new adopter and fix badge reference

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -55,7 +55,7 @@ You may also use the permalinks given above to reference from your project home 
 
 If you are using a markdown README file in your source code repository, you may want to add a badge like this one ![Contributor Covenant Badge](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg) using the code below.
 ```
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](code-of-conduct.md)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](code_of_conduct.md)
 ```
 
 *The Contributor Covenant is released under the [Creative Commons Attribution 4.0 International Public License](https://github.com/ContributorCovenant/contributor_covenant/blob/release/LICENSE.md), which requires that attribution be included.*

--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -109,6 +109,7 @@ HTML5 Boilerplate, https://github.com/h5bp/html5-boilerplate
 HTTPicnic, https://github.com/henry-anderson/HTTPicnic
 HTTPotion, https://github.com/myfreeweb/httpotion
 Huh? Dictionary, https://github.com/Yaacoub/Huh-Dictionary
+icepyx, https://github.com/icesat2py/icepyx
 if me, https://github.com/julianguyen/ifme
 Intel OTC, https://01.org/blogs/2018/intel-covenant-code
 iText, http://itextpdf.com/


### PR DESCRIPTION
icepyx has adopted the Contributor Covenant!

The suggested badge relative reference used - instead of _ and thus couldn't find the file.