### PR TITLE
Add Mapbox to adopters

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -134,6 +134,7 @@ Linux, https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit
 Lolcommits Plugins, https://github.com/search?q=topic%3Alolcommits-plugin+org%3Alolcommits
 Lolcommits, https://github.com/mroth/lolcommits
 Mailchain, https://github.com/mailchain/mailchain
+Mapbox, https://github.com/mapbox
 Maximilian, https://github.com/equinoxfitness/maximilian
 Marquez, https://github.com/MarquezProject/marquez
 Mensa, https://github.com/jordanekay/Mensa


### PR DESCRIPTION
Mapbox has adopted the Contributor Covenant for all public Github projects since 2015: https://blog.mapbox.com/our-code-of-conduct-for-open-source-2b3a81c00c80

Thanks for all your work @CoralineAda & team! :heart: 

cc @mourner @sgillies