### PR TITLE
Add Amsterdam.rb meetup to adopters list

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -8,6 +8,7 @@ ActsAsTextcaptcha, https://github.com/matthutchinson/acts_as_textcaptcha
 Algorithm Archive, https://github.com/algorithm-archivists/algorithm-archive
 Algorrent, https://github.com/algorrent/algorrent
 All Algorithms, https://github.com/abranhe/algorithms
+Amsterdam.rb, https://amsrb.org/code-of-conduct/
 Android IMSI-Catcher Detector, https://github.com/CellularPrivacy/Android-IMSI-Catcher-Detector
 angular-formly, https://github.com/formly-js/angular-formly
 AngularJS, https://github.com/angular/code-of-conduct


### PR DESCRIPTION
Add the Amsterdam based Ruby meetup (https://amsrb.org/) to the adopters
list.

I've added the entry to the list in alphabetical order as all other
entries seem to be.

---

Let me know if there's anything missing from this PR.