### PR TITLE
Add AppSignal to adopters list

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -13,6 +13,7 @@ Android IMSI-Catcher Detector, https://github.com/CellularPrivacy/Android-IMSI-C
 angular-formly, https://github.com/formly-js/angular-formly
 AngularJS, https://github.com/angular/code-of-conduct
 APInf, https://github.com/apinf/platform
+AppSignal, https://docs.appsignal.com/appsignal/code-of-conduct.html
 Asqatasun, https://github.com/Asqatasun/Asqatasun
 Atom, https://github.com/atom/atom
 AVA, https://github.com/avajs/ava


### PR DESCRIPTION
Add AppSignal (https://appsignal.com/) to the adopters list.
Code of Conduct location:
https://docs.appsignal.com/appsignal/code-of-conduct.html

---

Let me know if there's anything missing from this PR.