### PR TITLE
improve install script compatibility

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -35,8 +35,8 @@ Thanks to [Simon Vansintjan](https://github.com/simonv3/covenant-generator) ther
 Assuming that you have [Node.js](https://nodejs.org/en/ "Node.js Homepage") installed, simply run the following two commands from your project folder:
 
 ```
-npm install -g covgen
-covgen <your_email_address>
+npm install -g covgen; 
+covgen "<your_email_address>";
 ```
 
 If you have npm 5.x installed you can run `npx covgen <your_email_address>` instead of installing globally.


### PR DESCRIPTION
when running this command from certain circumstances, the newline in the HTML rendering of this page doesn't show up.
While on GitHub, it appears to always copy correctly. In at least a couple circumstances it renders all on one line.
78.0.1 (64-bit) Firefox Vanilla on Ubuntu Linux
Version 83.0.4103.116 (Official Build) (64-bit) Chrome with a bunch of about:flags on Ubuntu Linux
While visiting the main [https://www.contributor-covenant.org/](https://www.contributor-covenant.org/) website and then "ctrl+shift+v" pasting into Terminal
Appears something like this:
```
npm install -g covgen covgen <your_email_address>
```
I have screenshots too if this helps.