### PR TITLE
Add DevAndDev to adopters.csv

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -68,6 +68,7 @@ datacoco-secretsmanager, https://github.com/equinoxfitness/datacoco-secretsmanag
 Dawnscanner, https://github.com/thesp0nge/dawnscanner
 DC/OS, https://dcos.io/
 Dependent, https://github.com/dependent/dependencies
+DevAndDev, https://devand.dev
 Deviser Platform, https://github.com/deviserplatform/deviserplatform
 Diaspora, https://github.com/diaspora/diaspora
 Discourse, https://github.com/discourse/discourse


### PR DESCRIPTION
Hello, this to add DevAndDev (a website where developers can find pair-programming partners) as an adopter.
Thanks so much.