### PR TITLE
Cleanup of adopter list

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -1,19 +1,19 @@
-.NET Foundation, http://www.dotnetfoundation.org/code-of-conduct
+.NET Foundation, https://dotnetfoundation.org/about/code-of-conduct
 24 Pull Requests, https://github.com/24pullrequests/24pullrequests
 AASM, https://github.com/aasm/aasm
 ACM-W NITK, https://github.com/acm-w-nitk/acm-w-nitk.github.io
-Actionhero, https://www.actionherojs.com
+Actionhero, https://www.actionherojs.com/
 Active Admin, https://github.com/activeadmin/activeadmin
 ActsAsTextcaptcha, https://github.com/matthutchinson/acts_as_textcaptcha
 Algorithm Archive, https://github.com/algorithm-archivists/algorithm-archive
 Algorrent, https://github.com/algorrent/algorrent
-All Algorithms, https://github.com/abranhe/algorithms
+All Algorithms, https://github.com/AllAlgorithms/algorithms
 Amsterdam.rb, https://amsrb.org/code-of-conduct/
 Android IMSI-Catcher Detector, https://github.com/CellularPrivacy/Android-IMSI-Catcher-Detector
 angular-formly, https://github.com/formly-js/angular-formly
 AngularJS, https://github.com/angular/code-of-conduct
 APInf, https://github.com/apinf/platform
-AppSignal, https://docs.appsignal.com/appsignal/code-of-conduct.html
+AppSignal, https://docs.appsignal.com/appsignal/contributing/code-of-conduct.html
 Asqatasun, https://github.com/Asqatasun/Asqatasun
 Atom, https://github.com/atom/atom
 AVA, https://github.com/avajs/ava
@@ -21,29 +21,29 @@ Babel, https://github.com/babel/babel
 Baleen CLI, https://github.com/baleen/cli
 Baleen Migrations, https://github.com/baleen/migrations
 Begynner, https://github.com/marcker/begynner
-Bionode, http://bionode.io
+Bionode, https://www.bionode.io/
 BioSigKit, https://github.com/hooman650/BioSigKit
 bitmath, https://github.com/tbielawa/bitmath/
 BootstrapVue, https://github.com/bootstrap-vue/bootstrap-vue
-Bridge.NET, http://bridge.net
+Bridge.NET, https://bridge.net/
 brightness_bashshell_script, https://github.com/gorlapraveen/brightness_bashshell_script
-c-3po, https://c-3po.js.org
-Cake, http://cakebuild.net
+c-3po, https://c-3po.js.org/
+Cake, https://cakebuild.net/
 Calypso (WordPress.com), https://github.com/Automattic/wp-calypso
 Celluloid, https://github.com/celluloid/celluloid
-Cesium, https://github.com/AnalyticalGraphicsInc/cesium
+Cesium, https://github.com/CesiumGS/cesium
 Chalk, https://github.com/chalk/chalk
 Changelog.com, https://changelog.com/
 CHAOSS Project, https://chaoss.community/
 Checkstyle for Haxe, https://github.com/HaxeCheckstyle/haxe-checkstyle
-chef-rvm, https://github.com/fnichol/chef-rvm
+chef-rvm, https://github.com/sous-chefs/rvm
 clearwater.rb, https://github.com/clearwater-rb/clearwater
 Climate Equity Reference Calculator, https://github.com/climateequityreferenceproject/cerc-web
 CloudI, http://cloudi.org/faq.html#2_CodeOfConduct
 code.gov, https://github.com/GSA/code-gov/
 CocoaPods, https://github.com/cocoapods/cocoapods
 Codebridge, https://github.com/codebridge-za
-CodeBuddies, https://github.com/codebuddiesdotorg/cb-v2-scratch
+CodeBuddies, https://github.com/codebuddies/codebuddies
 Coding Coach, https://github.com/Coding-Coach/coding-coach
 composer, https://github.com/composer/composer
 comptoir-du-libre, https://gitlab.adullact.net/Comptoir/Comptoir-srv
@@ -52,10 +52,10 @@ conduct, https://github.com/sindresorhus/conduct
 Contrast-Finder, https://github.com/Asqatasun/Contrast-Finder
 Crackle, https://github.com/jordanekay/Crackle
 Create React App, https://github.com/facebook/create-react-app
-Creative Commons, http://creativecommons.github.io/community/code-of-conduct/
-Crystal, https://github.com/manastech/crystal
+Creative Commons, http://opensource.creativecommons.org/community/code-of-conduct/
+Crystal, https://github.com/crystal-lang/crystal
 Cucumber, https://github.com/cucumber
-curl, https://github.com/bagder/curl
+curl, https://github.com/curl/curl
 Data Retriever, https://github.com/weecology/retriever
 datacoco-batch, https://github.com/equinoxfitness/datacoco-batch
 datacoco-cloud, https://github.com/equinoxfitness/datacoco-cloud
@@ -68,7 +68,7 @@ datacoco-secretsmanager, https://github.com/equinoxfitness/datacoco-secretsmanag
 Dawnscanner, https://github.com/thesp0nge/dawnscanner
 DC/OS, https://dcos.io/
 Dependent, https://github.com/dependent/dependencies
-DevAndDev, https://devand.dev
+DevAndDev, https://devand.dev/
 Deviser Platform, https://github.com/deviserplatform/deviserplatform
 Diaspora, https://github.com/diaspora/diaspora
 Discourse, https://github.com/discourse/discourse
@@ -77,14 +77,14 @@ Dokku, https://github.com/dokku/dokku
 Doublify, https://github.com/doublify
 Drachenhorn, https://github.com/Drachenhorn-Team/Drachenhorn
 ECB Exchange, https://github.com/matthutchinson/ecb_exchange
-Eclipse Che, https://github.com/codenvy/che
-Eclipse, https://eclipse.org
+Eclipse Che, https://github.com/eclipse/che
+Eclipse, https://www.eclipse.org/
 Eldest Daughter Questionnaire, https://github.com/eldest-daughter/ed-questionnaire
 Electron, https://github.com/electron/electron
 Elixir, https://github.com/elixir-lang/elixir
-Exercism.io, https://github.com/exercism/exercism.io
+Exercism.io, https://github.com/exercism/exercism
 Firefox Browser to B2B Communication, https://github.com/gorlapraveen/firefox_b2b_comm_radio_addon
-First Contributions, https://github.com/multunus/first-contributions
+First Contributions, https://github.com/firstcontributions/first-contributions
 Freedomotic, https://github.com/freedomotic/freedomotic
 friends, https://github.com/JacobEvelyn/friends
 Fukuzatsu, https://gitlab.com/coraline/fukuzatsu/tree/master
@@ -92,100 +92,99 @@ Gatsby, https://github.com/gatsbyjs/gatsby
 GDS, https://github.com/alphagov
 GEOPM, https://geopm.github.io/
 GetTogether, https://github.com/GetTogetherComm/GetTogether
-git, https://github.com/gitster/git
+git, https://github.com/git/git
 Git for Windows, https://github.com/git-for-windows
-GitLab, https://gitlab.com/gitlab-org/gitlab-ce/
+GitLab, https://gitlab.com/gitlab-org/gitlab-foss/
 Giveth, https://wiki.giveth.io/policy/codeofconduct/
 GNSS-SDR, https://github.com/gnss-sdr/gnss-sdr
-GNU Guix and GuixSD, https://www.gnu.org/software/guix/
+GNU Guix and GuixSD, https://guix.gnu.org/
 Golang, https://golang.org/conduct
 Golden Cobra, https://github.com/ikuseiGmbH/Goldencobra
-Google, https://opensource.google.com/docs/releasing/template/CODE_OF_CONDUCT/
+Google, https://opensource.google/docs/releasing/template/CODE_OF_CONDUCT/
 GorangoCSS, https://gorangocss.kawanua.id/codeofconduct/
-GoReleaser, https://github.com/goreleaser/releaser
+GoReleaser, https://github.com/goreleaser/goreleaser
 Gremlins tracker for Visual Studio Code, https://github.com/nhoizey/vscode-gremlins
 Grape, https://github.com/ruby-grape/grape
 Growing Devs, https://github.com/growingdevs/growingdevs.github.io
-Hacken.in, https://github.com/hacken-in/website
-Hanami, http://hanamirb.org/community#code-of-conduct
+Hacken.in, https://github.com/hacken-in/hacken-in
+Hanami, http://hanamirb.org/community/#code-of-conduct
 HandBrake, https://github.com/HandBrake/HandBrake
-Haskell Fill in the Blanks, https://gitlab.com/cpp.cabrera/haskell-fill-in-the-blanks/tree/master
-HaskellNow.org, http://www.haskellnow.org/wiki/WikiStart#Projects
+HaskellNow.org, http://www.haskellnow.org/#Projects
 HealingRa.in Projects, https://gitlab.com/groups/healing-rain
-Heptio Ark, https://github.com/heptio/ark
-Heptio Contour, https://github.com/heptio/contour
-Heptio Gimbal, https://github.com/heptio/gimbal
-Heptio Sonobuoy, https://github.com/heptio/sonobuoy
+Heptio Ark, https://github.com/vmware-tanzu/velero
+Heptio Contour, https://github.com/projectcontour/contour
+Heptio Gimbal, https://github.com/projectcontour/gimbal
+Heptio Sonobuoy, https://github.com/vmware-tanzu/sonobuoy
 Holidays, https://github.com/holidays/holidays
-Homebrew-Cask, https://github.com/caskroom/homebrew-cask
+Homebrew-Cask, https://github.com/Homebrew/homebrew-cask
 Hotels.com, https://github.com/HotelsDotCom
 HTML5 Boilerplate, https://github.com/h5bp/html5-boilerplate
 HTTPicnic, https://github.com/henry-anderson/HTTPicnic
 HTTPotion, https://github.com/myfreeweb/httpotion
 Huh? Dictionary, https://github.com/Yaacoub/Huh-Dictionary
 icepyx, https://github.com/icesat2py/icepyx
-if me, https://github.com/julianguyen/ifme
+if me, https://github.com/ifmeorg/ifme
 Intel OTC, https://01.org/blogs/2018/intel-covenant-code
-iText, http://itextpdf.com/
+iText, https://itextpdf.com/en
 Java Builders Generator, https://github.com/khabali/java-builders-generator
 jekyll-octopod, https://jekyll-octopod.github.io/conduct/
 Jekyll, https://github.com/jekyll/jekyll
-Jenkins, https://jenkins-ci.org/conduct/
+Jenkins, https://www.jenkins.io/conduct/
 Johnny-Five, https://github.com/rwaldron/johnny-five
 JRuby Gradle, https://github.com/jruby-gradle/jruby-gradle-plugin
 JRuby, https://github.com/jruby/jruby/
-JuneteenthConf, https://juneteenthconf.com
+JuneteenthConf, https://juneteenthconf.com/
 json-rpc, https://github.com/pavlov99/json-rpc
 Kickoff, https://github.com/TryKickoff/kickoff/
 Kiva, https://github.com/kiva
-Kong, https://github.com/mashape/kong/
-Kornia, https://github.com/arraiyopensource/kornia
+Kong, https://github.com/Kong/kong/
+Kornia, https://github.com/kornia/kornia
 Kubernetes, https://github.com/kubernetes/kubernetes/
 LA Devs, https://github.com/la-devs/ladevs.org
-Laravel.io, https://github.com/laravelio/portal
+Laravel.io, https://github.com/laravelio/laravel.io
 LifxDash, https://github.com/matthutchinson/lifx_dash
 Linode, https://github.com/linode/docs
 Linux, https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=8a104f8b5867c682d994ffa7a74093c54469c11f
 Lolcommits Plugins, https://github.com/search?q=topic%3Alolcommits-plugin+org%3Alolcommits
-Lolcommits, https://github.com/mroth/lolcommits
+Lolcommits, https://github.com/lolcommits/lolcommits
 Mailchain, https://github.com/mailchain/mailchain
 Mapbox, https://github.com/mapbox
-Maximilian, https://github.com/equinoxfitness/maximilian
+Maximilian, https://github.com/WillLiu360/maximilian
 Marquez, https://github.com/MarquezProject/marquez
 Mensa, https://github.com/jordanekay/Mensa
-Meridian, https://github.com/untilnow/meridian
+Meridian, https://github.com/nicholaswyoung/meridian
 Metasploit, https://github.com/rapid7/metasploit-framework
 Mono, https://github.com/mono/mono
-Monsti CMS, http://www.monsti.org/
+Monsti CMS, http://monsti.org/
 Moya, https://github.com/Moya/Moya
-Mozilla Webmaker, https://www.webmaker.org/
-MyBB, https://mybb.com
+Mozilla Webmaker, https://foundation.mozilla.org/en/artifacts/webmaker/
+MyBB, https://mybb.com/
 MyPaint, https://github.com/mypaint/mypaint
-N#, github.com/n-language/n-
-Navidrome Music Server, https://www.navidrome.org
-NColony, https://github.com/moshez/ncolony
+N#, https://github.com/n-language/n-
+Navidrome Music Server, https://www.navidrome.org/
+NColony, https://github.com/ncolony/ncolony
 Neos, https://www.neos.io/
 Nerd Fonts, https://github.com/ryanoasis/nerd-fonts
 Nodejs Africa, https://nodejs.africa/
 Node.js, https://github.com/nodejs
 Noice, https://github.com/ashutoshgngwr/noice
-nteract, http://nteract.io/
+nteract, https://nteract.io/
 OAPI ShieldsUp, https://github.com/oapi/shieldsup
 Onnx-go, https://github.com/owulveryck/onnx-go
 Open WebRTC Toolkit, https://github.com/open-webrtc-toolkit
-OpenDominion, https://github.com/WaveHack/OpenDominion
-OpenDroneMap, https://github.com/OpenDroneMap/OpenDroneMap
+OpenDominion, https://github.com/OpenDominion/OpenDominion
+OpenDroneMap, https://github.com/OpenDroneMap/ODM
 OpenJS Foundation, https://github.com/openjs-foundation/
 OpenProject, https://www.openproject.org/
 Operable, https://github.com/operable/
 ORGENIC UI, https://github.com/orgenic/orgenic-ui
 Orientation, https://github.com/orientation/orientation
 Ornament, https://github.com/jordanekay/Ornament
-OWASP Juice Shop, https://owasp-juice.shop
+OWASP Juice Shop, https://owasp.org/www-project-juice-shop/
 OWASP ZAP, https://github.com/zaproxy/zaproxy
 Pale Moon, http://www.palemoon.org/
 Panamax, https://github.com/CenturyLinkLabs/panamax-ui
-Paramore, https://github.com/iancooper/Paramore
+Brighter, https://github.com/BrighterCommand/Brighter
 Pash, https://github.com/Pash-Project/Pash
 PatternFly, https://github.com/patternfly/patternfly
 Perfect, https://github.com/PerfectlySoft/Perfect
@@ -193,12 +192,12 @@ PeteBishwhip, https://github.com/PeteBishwhip/
 Pexip - Video Conferencing SDK, https://github.com/pexip/pexkit-sdk
 pg_chameleon - MySQL to PostgreSQL replica, https://github.com/the4thdoctor/pg_chameleon
 phpMyAdmin, https://www.phpmyadmin.net/
-pimutils, https://pimutils.org/coc
+pimutils, https://pimutils.org/coc/
 PiVPN, https://github.com/pivpn/pivpn
 Pixi.js Haxe Externs, https://github.com/pixijs/pixi-haxe
-Playscii, http://vectorpoem.com/playscii
+Playscii, http://vectorpoem.com/playscii/
 pmap, https://github.com/bruceadams/pmap
-Postwoman, https://github.com/liyasthomas/postwoman
+Hoppscotch, https://github.com/hoppscotch/hoppscotch
 postcss-glitch, https://github.com/crftd/postcss-glitch
 prance (Resolving Swagger/OpenAPI 2.0 Parser), https://github.com/jfinkhaeuser/prance
 PRAW, https://github.com/praw-dev/praw
@@ -209,13 +208,13 @@ PyBBIO, https://github.com/graycatlabs/PyBBIO
 PyMC3, https://github.com/pymc-devs/pymc3
 PyMC4, https://github.com/pymc-devs/pymc4
 Python-dwca-reader, https://github.com/BelgianBiodiversityPlatform/python-dwca-reader
-Python Girona, https://pythongirona.cat
+Python Girona, https://pythongirona.cat/
 QA-Tools, https://github.com/qa-tools/qa-tools
 Quack Lang, https://github.com/quack/quack
 Quick, https://github.com/Quick/Quick
-Rack::Attack, https://github.com/kickstarter/rack-attack
+Rack::Attack, https://github.com/rack/rack-attack
 Rails, https://github.com/rails/rails
-Random Bookmark From Folder, https://github.com/PikadudeNo1/RandomBookmark
+Random Bookmark From Folder, https://github.com/PixievoltNo1/RandomBookmark
 rbenv, https://github.com/rbenv/rbenv
 React, https://github.com/facebook/react
 ReactiveUI, https://github.com/reactiveui/reactiveui
@@ -230,7 +229,7 @@ ROM, https://github.com/rom-rb/rom
 RSpec, https://github.com/rspec/rspec
 Ruby for Cats, https://github.com/rubyforcats
 Ruby Hero Awards, https://github.com/rubyheroes/rubyheroes.com
-ruby-community, https://github.com/apeiros/ruby-community
+ruby-community, https://github.com/ruby-community/ruby-community
 RubyGems.org, https://github.com/rubygems/rubygems.org
 RVM, https://github.com/rvm/rvm
 Salesforce OSS, https://github.com/salesforce/oss-template
@@ -238,24 +237,24 @@ Sass Guidelines, https://github.com/HugoGiraudel/sass-guidelines
 SassDoc, https://github.com/sassdoc/sassdoc
 Scrapy, https://scrapy.org/
 Secrez, https://github.com/secrez/secrez
-Serialport, https://github.com/voodootikigod/node-serialport
+Serialport, https://github.com/serialport/node-serialport
 Sevilla Maker Society, https://github.com/maker-society-svq
 Skyscanner, https://github.com/skyscanner
 Snipe-IT, https://github.com/snipe/snipe-it
 Snuffle, https://gitlab.com/coraline/snuffle/tree/master
 Software Carpentry, https://github.com/swcarpentry
 Software Foundations Chinese Translation, https://github.com/Coq-zh/SF-zh
-SPIP, https://www.spip.net/
+SPIP, https://www.spip.net/fr_rubrique91.html
 Spree, https://github.com/spree/spree
 Spring Boot, https://github.com/spring-projects/spring-boot
 Spring, https://github.com/spring-projects
 Squirrel for Windows, https://github.com/squirrel/squirrel.windows
 Stack.io, https://github.com/germanstack
-Storybook, https://github.com/storybooks/storybook
+Storybook, https://github.com/storybookjs/storybook
 Styled Hooks, https://github.com/colingourlay/styled-hooks
 SuiteCRM, https://suitecrm.com/
-Supergiant, https://supergiant.io/
-Swathanthra Malayalam Computing, https://smc.org.in
+Supergiant, https://supergiant.io/thank-you/
+Swathanthra Malayalam Computing, https://smc.org.in/
 SwellRT, https://github.com/P2Pvalue/swellrt/
 Swift, https://swift.org/community/#code-of-conduct
 Symfony, https://github.com/symfony/symfony
@@ -270,7 +269,7 @@ Termidinator, https://github.com/Yaacoub/Termidinator
 The Anadromi Project, https://github.com/anadromi/the-anadromi-project
 The PHP League OAuth 2.0 Server, https://github.com/thephpleague/oauth2-server
 Tide, https://github.com/wptide/wptide
-TinyMCE, https://www.tinymce.com/docs/advanced/contributing-to-open-source/
+TinyMCE, https://www.tiny.cloud/docs/configure/contributing-to-open-source/
 Tmuxinator, https://github.com/tmuxinator/tmuxinator
 Travis CI, https://travis-ci.community/t/code-of-conduct/64
 Turbolinks, https://github.com/turbolinks/turbolinks
@@ -282,7 +281,7 @@ VideoSnap, https://github.com/matthutchinson/videosnap
 vim cheat sheet, https://github.com/rtorr/vim-cheat-sheet
 VimDevIcons, https://github.com/ryanoasis/vim-devicons
 VirtAPI-Stack, https://github.com/virtapi/
-Visual F#, https://github.com/Microsoft/visualfsharp
+Visual F#, https://github.com/dotnet/fsharp
 Volt.rb, https://github.com/voltrb/volt
 Vox Pupuli, https://voxpupuli.org/
 VSAlert, https://vsalert.vsanthanam.com

--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -26,6 +26,7 @@ BioSigKit, https://github.com/hooman650/BioSigKit
 bitmath, https://github.com/tbielawa/bitmath/
 BootstrapVue, https://github.com/bootstrap-vue/bootstrap-vue
 Bridge.NET, https://bridge.net/
+Brighter, https://github.com/BrighterCommand/Brighter
 brightness_bashshell_script, https://github.com/gorlapraveen/brightness_bashshell_script
 c-3po, https://c-3po.js.org/
 Cake, https://cakebuild.net/
@@ -111,12 +112,11 @@ Hanami, http://hanamirb.org/community/#code-of-conduct
 HandBrake, https://github.com/HandBrake/HandBrake
 HaskellNow.org, http://www.haskellnow.org/#Projects
 HealingRa.in Projects, https://gitlab.com/groups/healing-rain
-Heptio Ark, https://github.com/vmware-tanzu/velero
 Heptio Contour, https://github.com/projectcontour/contour
 Heptio Gimbal, https://github.com/projectcontour/gimbal
-Heptio Sonobuoy, https://github.com/vmware-tanzu/sonobuoy
 Holidays, https://github.com/holidays/holidays
 Homebrew-Cask, https://github.com/Homebrew/homebrew-cask
+Hoppscotch, https://github.com/hoppscotch/hoppscotch
 Hotels.com, https://github.com/HotelsDotCom
 HTML5 Boilerplate, https://github.com/h5bp/html5-boilerplate
 HTTPicnic, https://github.com/henry-anderson/HTTPicnic
@@ -184,7 +184,6 @@ OWASP Juice Shop, https://owasp.org/www-project-juice-shop/
 OWASP ZAP, https://github.com/zaproxy/zaproxy
 Pale Moon, http://www.palemoon.org/
 Panamax, https://github.com/CenturyLinkLabs/panamax-ui
-Brighter, https://github.com/BrighterCommand/Brighter
 Pash, https://github.com/Pash-Project/Pash
 PatternFly, https://github.com/patternfly/patternfly
 Perfect, https://github.com/PerfectlySoft/Perfect
@@ -197,7 +196,6 @@ PiVPN, https://github.com/pivpn/pivpn
 Pixi.js Haxe Externs, https://github.com/pixijs/pixi-haxe
 Playscii, http://vectorpoem.com/playscii/
 pmap, https://github.com/bruceadams/pmap
-Hoppscotch, https://github.com/hoppscotch/hoppscotch
 postcss-glitch, https://github.com/crftd/postcss-glitch
 prance (Resolving Swagger/OpenAPI 2.0 Parser), https://github.com/jfinkhaeuser/prance
 PRAW, https://github.com/praw-dev/praw
@@ -242,6 +240,7 @@ Sevilla Maker Society, https://github.com/maker-society-svq
 Skyscanner, https://github.com/skyscanner
 Snipe-IT, https://github.com/snipe/snipe-it
 Snuffle, https://gitlab.com/coraline/snuffle/tree/master
+Sonobuoy, https://github.com/vmware-tanzu/sonobuoy
 Software Carpentry, https://github.com/swcarpentry
 Software Foundations Chinese Translation, https://github.com/Coq-zh/SF-zh
 SPIP, https://www.spip.net/fr_rubrique91.html
@@ -276,6 +275,7 @@ Turbolinks, https://github.com/turbolinks/turbolinks
 Twilio, https://github.com/twilio
 Twisted, https://github.com/twisted/twisted
 UXP, https://github.com/MoonchildProductions/UXP
+Velero, https://github.com/vmware-tanzu/velero
 Video.js, https://github.com/videojs/video.js
 VideoSnap, https://github.com/matthutchinson/videosnap
 vim cheat sheet, https://github.com/rtorr/vim-cheat-sheet

--- a/static/featured-adopters.csv
+++ b/static/featured-adopters.csv
@@ -3,47 +3,47 @@ Atom, https://github.com/atom/atom
 AngularJS, https://github.com/angular/code-of-conduct
 Babel, https://github.com/babel/babel
 Bootstrap, https://github.com/twbs/bootstrap
-Bundler, https://github.com/bundler/bundler
-chef-rvm, https://github.com/fnichol/chef-rvm
-Cloud Native Compute Foundation, https://www.cncf.io
+Bundler, https://github.com/rubygems/bundler
+chef-rvm, https://github.com/sous-chefs/rvm
+Cloud Native Compute Foundation, https://www.cncf.io/
 CocoaPods, https://github.com/cocoapods/cocoapods
 code.gov, https://github.com/GSA/code-gov/
-Creative Commons, http://creativecommons.github.io/community/code-of-conduct/
+Creative Commons, http://opensource.creativecommons.org/community/code-of-conduct/
 Cucumber, https://github.com/cucumber
-Crystal, https://github.com/manastech/crystal
-curl, https://github.com/bagder/curl
-Diaspora, http://github.com/diaspora/diaspora
+Crystal, https://github.com/crystal-lang/crystal
+curl, https://github.com/curl/curl
+Diaspora, https://github.com/diaspora/diaspora
 Discourse, https://github.com/discourse/discourse
-Eclipse, https://eclipse.org
+Eclipse, https://www.eclipse.org/
 Electron, https://github.com/electron/electron
 Elixir, https://github.com/elixir-lang/elixir
-Exercism.io, https://github.com/exercism/exercism.io
+Exercism.io, https://github.com/exercism/exercism
 Gatsby, https://github.com/gatsbyjs/gatsby
-git, https://github.com/gitster/git
-GitLab, https://gitlab.com/gitlab-org/gitlab-ce/
+git, https://github.com/git/git
+GitLab, https://gitlab.com/gitlab-org/gitlab-foss/
 Golang, https://golang.org/conduct
-Google, https://opensource.google.com/docs/releasing/template/CODE_OF_CONDUCT/
-Homebrew-Cask, https://github.com/caskroom/homebrew-cask
+Google, https://opensource.google/docs/releasing/template/CODE_OF_CONDUCT/
+Homebrew-Cask, https://github.com/Homebrew/homebrew-cask
 Intel OTC, https://01.org/blogs/2018/intel-covenant-code
 Jekyll, https://github.com/jekyll/jekyll
-Jenkins, https://jenkins-ci.org/conduct/
+Jenkins, https://www.jenkins.io/conduct/
 JRuby, https://github.com/jruby/jruby/
-JuneteenthConf, https://juneteenthconf.com
-Hanami, http://hanamirb.org/community#code-of-conduct
-Kong, https://github.com/mashape/kong/
+JuneteenthConf, https://juneteenthconf.com/
+Hanami, http://hanamirb.org/community/#code-of-conduct
+Kong, https://github.com/Kong/kong/
 Kubernetes, https://github.com/kubernetes/kubernetes/
 Linux, https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=8a104f8b5867c682d994ffa7a74093c54469c11f
 Metasploit Framework, https://github.com/rapid7/metasploit-framework
 Mono, https://github.com/mono/mono
-Mozilla Webmaker, https://www.webmaker.org/
-.NET Foundation, http://www.dotnetfoundation.org/code-of-conduct
+Mozilla Webmaker, https://foundation.mozilla.org/en/artifacts/webmaker/
+.NET Foundation, https://dotnetfoundation.org/about/code-of-conduct
 Node.js, https://github.com/nodejs
 Rails, https://github.com/rails/rails
 rbenv, https://github.com/rbenv/rbenv
 React, https://github.com/facebook/react
 ROM, https://github.com/rom-rb/rom
 RSpec, https://github.com/rspec/rspec
-ruby-community, https://github.com/apeiros/ruby-community
+ruby-community, https://github.com/ruby-community/ruby-community
 rubygems, https://github.com/rubygems/rubygems
 RubyGems.org, https://github.com/rubygems/rubygems.org
 RVM, https://github.com/rvm/rvm
@@ -56,6 +56,6 @@ Target, https://github.com/target
 TensorFlow, https://github.com/tensorflow/tensorflow
 Travis CI, https://travis-ci.community/t/code-of-conduct/64
 Twilio, https://github.com/twilio
-Visual F#, https://github.com/Microsoft/visualfsharp
+Visual F#, https://github.com/dotnet/fsharp
 Vue.js, https://github.com/vuejs/vue
 Yarn, https://github.com/yarnpkg/yarn


### PR DESCRIPTION
After noticing that the location of some repositories on the featured adopter list changed or redirected to a different location I decided to update all of them using a script. For now these links still redirect to their new location, but this may change in the future once pages shuffle around again, so I think it is better to update their location now and check for redirects regularly.

Furthermore I noticed some projects no longer have a visible web presence, so they were removed (Haskell Fill in the Blanks). A few more projects are now inactive and maybe should be removed (Mozilla Webmaker and others), but I didn't check for that and as this may be subjective this should probably be done by a core contributor.

Please review commit by commit, the first commit just update links, the second commit has moved projects that renamed around to their new location to keep the list sorted.