### PR TITLE
Add SaltStack

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -233,6 +233,7 @@ ruby-community, https://github.com/ruby-community/ruby-community
 RubyGems.org, https://github.com/rubygems/rubygems.org
 RVM, https://github.com/rvm/rvm
 Salesforce OSS, https://github.com/salesforce/oss-template
+SaltStack, https://github.com/saltstack/salt
 Sass Guidelines, https://github.com/HugoGiraudel/sass-guidelines
 SassDoc, https://github.com/sassdoc/sassdoc
 Scrapy, https://scrapy.org/


### PR DESCRIPTION
SaltStack uses the Contributor Covenant as their `CODE_OF_CONDUCT.md` within projects like https://github.com/saltstack/salt