### PR TITLE
Added code_of_conduct.pt-br.md

### DIFF
--- a/content/version/2/0/code_of_conduct.pt-br.md
+++ b/content/version/2/0/code_of_conduct.pt-br.md
@@ -3,13 +3,13 @@ version = "2.0"
 aliases = ["/version/2/0"]
 +++
 
-# Código de Conduta para Colaboradores
+# Código de Conduta de Colaboração
 
 ## Nossa promessa
 
-Como participantes, colaboradores e lideranças, nós nos comprometemos a fazer com que a participação em nossa comunidade seja uma experiência livre de assédio para todas as pessoas, independentemente de idade, tamanho do corpo, deficiência aparente ou não aparente, etnia, características sexuais, identidade ou expressão de gênero, nível de experiência, educação, situação sócio-econômica, nacionalidade, aparência pessoal, raça, religião ou identidade e orientação sexuais.
+Como pessoas participantes, colaboradoras e líderes, nós nos comprometemos a fazer com que a participação em nossa comunidade seja uma experiência livre de assédio para todas as pessoas, independentemente de idade, tamanho do corpo, deficiência aparente ou não aparente, etnia, características sexuais, identidade ou expressão de gênero, nível de experiência, educação, situação sócio-econômica, nacionalidade, aparência pessoal, raça, religião ou identidade e orientação sexuais.
 
-Comprometemo-nos a agir e interagir de maneiras que contribuem para uma comunidade aberta, acolhedora, diversificada, inclusiva e saudável.
+Comprometemo-nos a agir e interagir de maneiras que contribuam para uma comunidade aberta, acolhedora, diversificada, inclusiva e saudável.
 
 ## Nossos padrões
 
@@ -23,7 +23,7 @@ Exemplos de comportamentos que contribuem para criar um ambiente positivo para a
 
 Exemplos de comportamentos inaceitáveis incluem:
 
-* Uso de linguagem ou imagens sexuais e atenção ou avanço sexual de qualquer natureza
+* Uso de linguagem ou imagens sexualizadas, bem como o assédio sexual ou de qualquer natureza
 * Comentários insultuosos/depreciativos e ataques pessoais ou políticos (*Trolling*)
 * Assédio público ou privado
 * Publicar informações particulares de outras pessoas, como um endereço de e-mail ou endereço físico, sem a permissão explícita delas
@@ -43,6 +43,7 @@ Exemplos de representação da nossa comunidade incluem usar um endereço de e-m
 ## Aplicação
 
 Ocorrências de comportamentos abusivos, de assédio ou que sejam inaceitáveis por qualquer outro motivo poderão ser reportadas para a liderança da comunidade, responsável pela aplicação, via contato [INSERIR MÉTODO DE CONTATO].
+
 Todas as reclamações serão revisadas e investigadas imediatamente e de maneira justa.
 
 A liderança da comunidade tem a obrigação de respeitar a privacidade e a segurança de quem reportar qualquer incidente.

--- a/content/version/2/0/code_of_conduct.pt-br.md
+++ b/content/version/2/0/code_of_conduct.pt-br.md
@@ -1,0 +1,90 @@
++++
+version = "2.0"
+aliases = ["/version/2/0"]
++++
+
+# Código de Conduta para Colaborantes
+
+## Nossa promessa
+
+Nós, como participantes, contribuintes e lideranças, nos comprometemos a fazer com que a participação em nossa comunidade seja uma experiência livre de assédio para todas as pessoas, independentemente de idade, tamanho do corpo, deficiência aparente ou não aparente, etnia, características sexuais, identidade ou expressão de gênero, nível de experiência, educação, situação sócio-econômica, nacionalidade, aparência pessoal, raça, religião ou identidade e orientação sexuais.
+
+Comprometemo-nos a agir e interagir de maneiras que contribuem para uma comunidade aberta, acolhedora, diversificada, inclusiva e saudável.
+
+## Nossos padrões
+
+Exemplos de comportamentos que contribuem para criar um ambiente positivo para a nossa comunidade incluem:
+
+* Demonstrar empatia e bondade com as outras pessoas
+* Respeitar opiniões contrárias, pontos de vista e experiências
+* Dar e receber feedbacks construtivos de maneira graciosa
+* Assumir responsabilidade e pedir desculpas para as pessoas afetadas por nossos erros e aprender com a experiência
+* Focar no que é melhor não só para nós individualmente, mas para a comunidade em geral
+
+Exemplos de comportamentos inaceitáveis incluem:
+
+* Uso de linguagem ou imagens sexuais e atenção ou avanço sexual de qualquer natureza
+* Comentários insultuosos/depreciativos e ataques pessoais ou políticos (*Trolling*)
+* Assédio público ou privado
+* Publicar informações particulares de outras pessoas, como um endereço de e-mail ou endereço físico, sem a permissão explícita delas
+* Outras condutas que são normalmente consideradas inapropriadas em um ambiente profissional
+
+## Aplicação das nossas responsibilities
+
+As lideranças da comunidade são responsáveis por clarificar e aplicar nossos padrões de comportamento aceitável e tomarão ações corretivas apropriadas e justas em resposta a qualquer comprotamento que considerarem impróprio, ameaçador, ofensivo ou problemático.
+
+As lideranças da comunidade têm o direito e a responsabilidade de remover, editar ou rejeitar comentários, commits, códigos, edições na wiki, erros e outras contribuições que não estão alinhadas com este Código de Conduta e irão comunicar as razões por trás das decisões da moderação quando for apropriado.
+
+## Escopo
+
+Este Código de Conduta se aplica dentro de todos os espaços da comunidade e também se aplica quando uma pessoa estiver representando oficialmente a comunidade em espaços públicos.
+Exemplos de representação da nossa comunidade incluem usar um endereço de e-mail oficial, postar em contas oficiais de mídias sociais ou atuar como uma pessoa indicada a representante em um evento online ou offline.
+
+## Aplicação
+
+Ocorrências de comportamentos abusivos, de assédio ou inaceitáveis por qualquer outro motivo poderão ser reportadas para as lideranças da comunidade responsáveis pela aplicação, via contato [INSERIR MÉTODO DE CONTATO].
+Todas as reclamações serão revisadas e investigadas imediatamente e de maneira justa.
+
+Todas as lideranças da comunidade têm a obrigação de respeitar a privacidade e A segurança de quem reportar qualquer incidente.
+
+## Diretrizes de aplicação
+
+As lideranças da comunidade seguirão estas Diretrizes de Impacto na Comunidade para determinar as consequências de qualquer ação que considerarem violadora deste Código de Conduta:
+
+### 1. Ação corretiva
+
+**Impacto na comunidade**: Uso de linguagem imprópria ou outro comportamento considerado anti-profissional ou repudiado pela comunidade.
+
+**Consequência**: Um aviso escrito e privado das lideranças da comunidade, esclarecendo a natureza da violação e uma explicação do motivo pelo qual o comportamento era impróprio. Um pedido de desculpas público poderá ser solicitado.
+
+### 2. Advertêcia
+
+**Impacto na comunidade**: Uma violação por meio de um incidente único ou atitudes repetidas.
+
+**Consequência**: Uma advertência com consequências para comportamento repetido. Não poderá haver interações com as pessoas envolvidas, incluindo interações não solicitadas com as pessoas que estiverem aplicando o Código de Conduta, por um período determinado. Isto inclui evitar interações em espaços da comunidade, bem como canais externos como as mídias sociais. A violação destes termos podem levar a um banimento temporário ou permanente.
+
+### 3. Banimento Temporário
+
+**Impacto na comunidade**: Uma violação grave dos padrões da comunidade, incluindo o comportamento impróprio constante.
+
+**Consequência**: Banimento temporário de qualquer tipo de interação ou comunicação pública com a comunidade por um determinado período. Estarão proibidas as interações públicas ou privadas com as pessoas envolvidas, incluindo interações não solicitadas com as pessoas que estiverem aplicando o Código de Conduta. A violação destes termos podem resultar em um banimento permanente.
+
+### 4. Banimento Permanente
+
+**Impacto na comunidade**: Demonstrar um padrão na violação das normas da comunidade, incluindo o comportamento impróprio constante, assédio a uma pessoa ou agressão ou depreciação a classes de pessoas.
+
+**Consequência**: Banimento permanente de qualquer tipo de interação pública dentro da comunidade.
+
+## Atribuição
+
+Este Código de Conduta é adaptado do [Contributor Covenant][homepage],
+versão 2.0, disponível em
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+As Diretrizes de Impacto na Comunidade foram inspiradas pela [Aplicação do código de conduta Mozilla](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+Para obter respostas a perguntas comuns sobre este código de conduta, veja a página de Perguntas Frequentes (*FAQ*) em
+https://www.contributor-covenant.org/faq. Traduções estão disponíveis em
+https://www.contributor-covenant.org/translations.

--- a/content/version/2/0/code_of_conduct.pt-br.md
+++ b/content/version/2/0/code_of_conduct.pt-br.md
@@ -3,11 +3,11 @@ version = "2.0"
 aliases = ["/version/2/0"]
 +++
 
-# Código de Conduta para Colaborantes
+# Código de Conduta para Colaboradores
 
 ## Nossa promessa
 
-Nós, como participantes, contribuintes e lideranças, nos comprometemos a fazer com que a participação em nossa comunidade seja uma experiência livre de assédio para todas as pessoas, independentemente de idade, tamanho do corpo, deficiência aparente ou não aparente, etnia, características sexuais, identidade ou expressão de gênero, nível de experiência, educação, situação sócio-econômica, nacionalidade, aparência pessoal, raça, religião ou identidade e orientação sexuais.
+Como participantes, colaboradores e lideranças, nós nos comprometemos a fazer com que a participação em nossa comunidade seja uma experiência livre de assédio para todas as pessoas, independentemente de idade, tamanho do corpo, deficiência aparente ou não aparente, etnia, características sexuais, identidade ou expressão de gênero, nível de experiência, educação, situação sócio-econômica, nacionalidade, aparência pessoal, raça, religião ou identidade e orientação sexuais.
 
 Comprometemo-nos a agir e interagir de maneiras que contribuem para uma comunidade aberta, acolhedora, diversificada, inclusiva e saudável.
 
@@ -16,9 +16,9 @@ Comprometemo-nos a agir e interagir de maneiras que contribuem para uma comunida
 Exemplos de comportamentos que contribuem para criar um ambiente positivo para a nossa comunidade incluem:
 
 * Demonstrar empatia e bondade com as outras pessoas
-* Respeitar opiniões contrárias, pontos de vista e experiências
-* Dar e receber feedbacks construtivos de maneira graciosa
-* Assumir responsabilidade e pedir desculpas para as pessoas afetadas por nossos erros e aprender com a experiência
+* Respeitar opiniões, pontos de vista e experiências contrárias
+* Dar e receber feedbacks construtivos de maneira respeitosa
+* Assumir responsabilidade, pedir desculpas às pessoas afetadas por nossos erros e aprender com a experiência
 * Focar no que é melhor não só para nós individualmente, mas para a comunidade em geral
 
 Exemplos de comportamentos inaceitáveis incluem:
@@ -29,49 +29,49 @@ Exemplos de comportamentos inaceitáveis incluem:
 * Publicar informações particulares de outras pessoas, como um endereço de e-mail ou endereço físico, sem a permissão explícita delas
 * Outras condutas que são normalmente consideradas inapropriadas em um ambiente profissional
 
-## Aplicação das nossas responsibilities
+## Aplicação das nossas responsabilidades
 
-As lideranças da comunidade são responsáveis por clarificar e aplicar nossos padrões de comportamento aceitável e tomarão ações corretivas apropriadas e justas em resposta a qualquer comprotamento que considerarem impróprio, ameaçador, ofensivo ou problemático.
+A liderança da comunidade é responsável por esclarecer e aplicar nossos padrões de comportamento aceitáveis e tomará ações corretivas apropriadas e justas em resposta a qualquer comportamento que considerar impróprio, ameaçador, ofensivo ou problemático.
 
-As lideranças da comunidade têm o direito e a responsabilidade de remover, editar ou rejeitar comentários, commits, códigos, edições na wiki, erros e outras contribuições que não estão alinhadas com este Código de Conduta e irão comunicar as razões por trás das decisões da moderação quando for apropriado.
+A liderança da comunidade tem o direito e a responsabilidade de remover, editar ou rejeitar comentários, commits, códigos, edições na wiki, erros e outras contribuições que não estão alinhadas com este Código de Conduta e irá comunicar as razões por trás das decisões da moderação quando for apropriado.
 
 ## Escopo
 
 Este Código de Conduta se aplica dentro de todos os espaços da comunidade e também se aplica quando uma pessoa estiver representando oficialmente a comunidade em espaços públicos.
-Exemplos de representação da nossa comunidade incluem usar um endereço de e-mail oficial, postar em contas oficiais de mídias sociais ou atuar como uma pessoa indicada a representante em um evento online ou offline.
+Exemplos de representação da nossa comunidade incluem usar um endereço de e-mail oficial, postar em contas oficiais de mídias sociais ou atuar como uma pessoa indicada como representante em um evento online ou offline.
 
 ## Aplicação
 
-Ocorrências de comportamentos abusivos, de assédio ou inaceitáveis por qualquer outro motivo poderão ser reportadas para as lideranças da comunidade responsáveis pela aplicação, via contato [INSERIR MÉTODO DE CONTATO].
+Ocorrências de comportamentos abusivos, de assédio ou que sejam inaceitáveis por qualquer outro motivo poderão ser reportadas para a liderança da comunidade, responsável pela aplicação, via contato [INSERIR MÉTODO DE CONTATO].
 Todas as reclamações serão revisadas e investigadas imediatamente e de maneira justa.
 
-Todas as lideranças da comunidade têm a obrigação de respeitar a privacidade e A segurança de quem reportar qualquer incidente.
+A liderança da comunidade tem a obrigação de respeitar a privacidade e a segurança de quem reportar qualquer incidente.
 
 ## Diretrizes de aplicação
 
-As lideranças da comunidade seguirão estas Diretrizes de Impacto na Comunidade para determinar as consequências de qualquer ação que considerarem violadora deste Código de Conduta:
+A liderança da comunidade seguirá estas Diretrizes de Impacto na Comunidade para determinar as consequências de qualquer ação que considerar violadora deste Código de Conduta:
 
-### 1. Ação corretiva
+### 1. Ação Corretiva
 
 **Impacto na comunidade**: Uso de linguagem imprópria ou outro comportamento considerado anti-profissional ou repudiado pela comunidade.
 
-**Consequência**: Um aviso escrito e privado das lideranças da comunidade, esclarecendo a natureza da violação e uma explicação do motivo pelo qual o comportamento era impróprio. Um pedido de desculpas público poderá ser solicitado.
+**Consequência**: Aviso escrito e privado da liderança da comunidade, esclarecendo a natureza da violação e com a explicação do motivo pelo qual o comportamento era impróprio. Um pedido de desculpas público poderá ser solicitado.
 
-### 2. Advertêcia
+### 2. Advertência
 
-**Impacto na comunidade**: Uma violação por meio de um incidente único ou atitudes repetidas.
+**Impacto na comunidade**: Violação por meio de um incidente único ou atitudes repetidas.
 
-**Consequência**: Uma advertência com consequências para comportamento repetido. Não poderá haver interações com as pessoas envolvidas, incluindo interações não solicitadas com as pessoas que estiverem aplicando o Código de Conduta, por um período determinado. Isto inclui evitar interações em espaços da comunidade, bem como canais externos como as mídias sociais. A violação destes termos podem levar a um banimento temporário ou permanente.
+**Consequência**: Advertência com consequências para comportamento repetido. Não poderá haver interações com as pessoas envolvidas, incluindo interações não solicitadas com as pessoas que estiverem aplicando o Código de Conduta, por um período determinado. Isto inclui evitar interações em espaços da comunidade, bem como canais externos como as mídias sociais. A violação destes termos pode levar a um banimento temporário ou permanente.
 
 ### 3. Banimento Temporário
 
-**Impacto na comunidade**: Uma violação grave dos padrões da comunidade, incluindo o comportamento impróprio constante.
+**Impacto na comunidade**: Violação grave dos padrões da comunidade, incluindo a persistência do comportamento impróprio.
 
-**Consequência**: Banimento temporário de qualquer tipo de interação ou comunicação pública com a comunidade por um determinado período. Estarão proibidas as interações públicas ou privadas com as pessoas envolvidas, incluindo interações não solicitadas com as pessoas que estiverem aplicando o Código de Conduta. A violação destes termos podem resultar em um banimento permanente.
+**Consequência**: Banimento temporário de qualquer tipo de interação ou comunicação pública com a comunidade por um determinado período. Estarão proibidas as interações públicas ou privadas com as pessoas envolvidas, incluindo interações não solicitadas com as pessoas que estiverem aplicando o Código de Conduta. A violação destes termos pode resultar em um banimento permanente.
 
 ### 4. Banimento Permanente
 
-**Impacto na comunidade**: Demonstrar um padrão na violação das normas da comunidade, incluindo o comportamento impróprio constante, assédio a uma pessoa ou agressão ou depreciação a classes de pessoas.
+**Impacto na comunidade**: Demonstrar um padrão na violação das normas da comunidade, incluindo a persistência do comportamento impróprio, assédio a uma pessoa ou agressão ou depreciação a classes de pessoas.
 
 **Consequência**: Banimento permanente de qualquer tipo de interação pública dentro da comunidade.
 


### PR DESCRIPTION
My translation of the Code of Conduct to Brazilian Portuguese.
I checked the existing pt-br file in v1 and used it as a reference, so the writing style doesn't get too different between versions.
I also made the writing as inclusive as possible, avoiding the use of gender specific language.