### PR TITLE
Add german translation v2.0

### DIFF
--- a/content/version/2/0/code_of_conduct.de.md
+++ b/content/version/2/0/code_of_conduct.de.md
@@ -35,9 +35,9 @@ Gemeinschaft beitragen, sind:
 Beispiele für inakzeptables Verhalten sind:
 
 - Die Verwendung sexualisierter Sprache, Bilder oder Symbolik sowie unerwünschte
-  Versuche sexueller Anbahnung
-- Beleidigende oder abwertende Kommentare, persönliche oder politische Angriffe,
-  Nutzung des Internets für unbilliges Verhalten
+  Versuche sexueller Annäherung
+- Beleidigende oder abwertende Kommentare, persönliche oder politische Angriffe
+  und trollen
 - Öffentliche oder private Belästigungen
 - Das Veröffentlichen von privaten Informationen Anderer, wie zum Beispiel
   physische oder elektronische Adressen, ohne deren ausdrückliche Erlaubnis
@@ -46,12 +46,12 @@ Beispiele für inakzeptables Verhalten sind:
 
 ## Verantwortlichkeiten bei der Durchsetzung
 
-Die Gemeinschaftsleitenden sind verantwortlich dafür, unsere Standards für ein
+Die Gemeinschaftsleitung sind verantwortlich dafür, unsere Standards für ein
 akzeptables Benehmen klarzustellen und werden angemessen und fair
 korrigierende Maßnahmen ergreifen um auf jegliches Verhalten, das sie für
 unangemessen, bedrohlich oder beleidigend halten, zu reagieren.
 
-Die Gemeinschaftsleitenden haben das Recht und die Verantwortung Kommentare,
+Die Gemeinschaftsleitung haben das Recht und die Verantwortung Kommentare,
 Commits, Code, Wiki-Bearbeitungen, Support-Tickets und andere Beiträge, die
 nicht mit diesem Verhaltenskodex vereinbar sind zu entfernen, zu bearbeiten oder
 abzulehnen, und werden die Gründe für eine Mäßigung mitteilen, wenn es
@@ -70,15 +70,15 @@ Offline-Veranstaltung.
 
 Fälle von missbräuchlichem, belästigendem oder anderweitig inakzeptablem
 Verhalten können unter [KONTAKTMETHODE EINFÜGEN] den für die Durchsetzung
-zuständigen Gemeinschaftsleitenden gemeldet werden. Alle Beschwerden werden
+zuständigen Gemeinschaftsleitung gemeldet werden. Alle Beschwerden werden
 zeitnah und fair geprüft und ermittelt.
 
-Alle Gemeinschaftsleitenden sind verpflichtet, die Privatsphäre und die
+Alle Gemeinschaftsleitung sind verpflichtet, die Privatsphäre und die
 Sicherheit derjenigen, die einen Vorfall gemeldet haben, zu respektieren.
 
 ## Durchsetzungsrichtlinien
 
-Die Gemeinschaftsleitenden werden sich bei der Bestimmung der Konsequenzen für
+Die Gemeinschaftsleitung werden sich bei der Bestimmung der Konsequenzen für
 jede Handlung, die ihrer Ansicht nach gegen diesen Verhaltenskodex verstößt, an
 diese Richtlinien über die Auswirkungen in der Gemeinschaft halten:
 
@@ -88,10 +88,10 @@ diese Richtlinien über die Auswirkungen in der Gemeinschaft halten:
 anderes Verhalten, das in der Gemeinschaft als unprofessionell oder unwillkommen
 gilt.
 
-**Folge**: Eine private, schriftliche Verwarnung von den
-Gemeinschaftsleitenden, die Klarheit über die Art des Verstoßes und eine
-Erklärung dafür bietet, warum das Verhalten unangemessen war. Eine öffentliche
-Entschuldigung kann verlangt werden.
+**Folge**: Eine private, schriftliche Verwarnung von den Gemeinschaftsleitung,
+die Klarheit über die Art des Verstoßes und eine Erklärung dafür bietet, warum
+das Verhalten unangemessen war. Eine öffentliche Entschuldigung kann verlangt
+werden.
 
 ### 2. Verwarnung
 

--- a/content/version/2/0/code_of_conduct.de.md
+++ b/content/version/2/0/code_of_conduct.de.md
@@ -46,12 +46,12 @@ Beispiele für inakzeptables Verhalten sind:
 
 ## Verantwortlichkeiten bei der Durchsetzung
 
-Die Gemeinschaftsleitung sind verantwortlich dafür, unsere Standards für ein
+Die Gemeinschaftsleitung ist verantwortlich dafür, unsere Standards für ein
 akzeptables Benehmen klarzustellen und werden angemessen und fair
 korrigierende Maßnahmen ergreifen um auf jegliches Verhalten, das sie für
 unangemessen, bedrohlich oder beleidigend halten, zu reagieren.
 
-Die Gemeinschaftsleitung haben das Recht und die Verantwortung Kommentare,
+Die Gemeinschaftsleitung hat das Recht und die Verantwortung Kommentare,
 Commits, Code, Wiki-Bearbeitungen, Support-Tickets und andere Beiträge, die
 nicht mit diesem Verhaltenskodex vereinbar sind zu entfernen, zu bearbeiten oder
 abzulehnen, und werden die Gründe für eine Mäßigung mitteilen, wenn es
@@ -69,16 +69,16 @@ Offline-Veranstaltung.
 ## Umsetzung
 
 Fälle von missbräuchlichem, belästigendem oder anderweitig inakzeptablem
-Verhalten können unter [KONTAKTMETHODE EINFÜGEN] den für die Durchsetzung
+Verhalten können unter [KONTAKTMETHODE EINFÜGEN] der für die Durchsetzung
 zuständigen Gemeinschaftsleitung gemeldet werden. Alle Beschwerden werden
 zeitnah und fair geprüft und ermittelt.
 
-Alle Gemeinschaftsleitung sind verpflichtet, die Privatsphäre und die
+Die gesamte Gemeinschaftsleitung ist verpflichtet, die Privatsphäre und die
 Sicherheit derjenigen, die einen Vorfall gemeldet haben, zu respektieren.
 
 ## Durchsetzungsrichtlinien
 
-Die Gemeinschaftsleitung werden sich bei der Bestimmung der Konsequenzen für
+Die Gemeinschaftsleitung wird sich bei der Bestimmung der Konsequenzen für
 jede Handlung, die ihrer Ansicht nach gegen diesen Verhaltenskodex verstößt, an
 diese Richtlinien über die Auswirkungen in der Gemeinschaft halten:
 
@@ -88,7 +88,7 @@ diese Richtlinien über die Auswirkungen in der Gemeinschaft halten:
 anderes Verhalten, das in der Gemeinschaft als unprofessionell oder unwillkommen
 gilt.
 
-**Folge**: Eine private, schriftliche Verwarnung von den Gemeinschaftsleitung,
+**Folge**: Eine private, schriftliche Verwarnung der Gemeinschaftsleitung,
 die Klarheit über die Art des Verstoßes und eine Erklärung dafür bietet, warum
 das Verhalten unangemessen war. Eine öffentliche Entschuldigung kann verlangt
 werden.

--- a/content/version/2/0/code_of_conduct.de.md
+++ b/content/version/2/0/code_of_conduct.de.md
@@ -7,7 +7,7 @@ aliases = ["/version/2/0/de"]
 
 ## Unsere Verpflichtung
 
-Wir als Mitglieder, Teilnehmer und Verantwortliche unserer Gemeinschaft
+Wir als Mitglieder, Teilnehmende und Verantwortliche unserer Gemeinschaft
 verpflichten uns bei der Teilnahme an dem Projekt und unserer Gemeinschaft zu
 einer belästigungsfreien Erfahrung für jeden, unabhängig von Alter, Körpergröße,
 Behinderung, ethnischer Zuordnung, geschlechtlicher Identität und Ausdruck,
@@ -46,16 +46,16 @@ Beispiele für inakzeptables Verhalten sind:
 
 ## Verantwortlichkeiten bei der Durchsetzung
 
-Die Gemeinschaftsleiter sind verantwortlich dafür, unsere Standards für ein
+Die Gemeinschaftsleitenden sind verantwortlich dafür, unsere Standards für ein
 akzeptables Benehmen klarzustellen und werden angemessen und fair
 korrigierende Maßnahmen ergreifen um auf jegliches Verhalten, das sie für
 unangemessen, bedrohlich oder beleidigend halten, zu reagieren.
 
-Die Gemeinschaftsleiter haben das Recht und die Verantwortung Kommentare,
+Die Gemeinschaftsleitenden haben das Recht und die Verantwortung Kommentare,
 Commits, Code, Wiki-Bearbeitungen, Support-Tickets und andere Beiträge, die
 nicht mit diesem Verhaltenskodex vereinbar sind zu entfernen, zu bearbeiten oder
-abzulehnen, und wird die Gründe für eine Mäßigung mitteilen, wenn es angebracht
-ist.
+abzulehnen, und werden die Gründe für eine Mäßigung mitteilen, wenn es
+angebracht ist.
 
 ## Geltungsbereich
 
@@ -70,17 +70,17 @@ Offline-Veranstaltung.
 
 Fälle von missbräuchlichem, belästigendem oder anderweitig inakzeptablem
 Verhalten können unter [KONTAKTMETHODE EINFÜGEN] den für die Durchsetzung
-zuständigen Gemeinschaftsleitern gemeldet werden. Alle Beschwerden werden
+zuständigen Gemeinschaftsleitenden gemeldet werden. Alle Beschwerden werden
 zeitnah und fair geprüft und ermittelt.
 
-Alle Gemeinschaftsleiter sind verpflichtet, die Privatsphäre und Sicherheit
-desjenigen, der einen Vorfall gemeldet hat, zu respektieren.
+Alle Gemeinschaftsleitenden sind verpflichtet, die Privatsphäre und die
+Sicherheit derjenigen, die einen Vorfall gemeldet haben, zu respektieren.
 
 ## Durchsetzungsrichtlinien
 
-Die Gemeinschaftsleiter werden sich bei der Bestimmung der Konsequenzen für jede
-Handlung, die ihrer Ansicht nach gegen diesen Verhaltenskodex verstößt, an diese
-Richtlinien über die Auswirkungen in der Gemeinschaft halten:
+Die Gemeinschaftsleitenden werden sich bei der Bestimmung der Konsequenzen für
+jede Handlung, die ihrer Ansicht nach gegen diesen Verhaltenskodex verstößt, an
+diese Richtlinien über die Auswirkungen in der Gemeinschaft halten:
 
 ### 1. Berichtigung
 
@@ -88,10 +88,10 @@ Richtlinien über die Auswirkungen in der Gemeinschaft halten:
 anderes Verhalten, das in der Gemeinschaft als unprofessionell oder unwillkommen
 gilt.
 
-**Folge**: Eine private, schriftliche Verwarnung von den Gemeinschaftsleitern,
-die Klarheit über die Art des Verstoßes und eine Erklärung dafür bietet, warum
-das Verhalten unangemessen war. Eine öffentliche Entschuldigung kann verlangt
-werden.
+**Folge**: Eine private, schriftliche Verwarnung von den
+Gemeinschaftsleitenden, die Klarheit über die Art des Verstoßes und eine
+Erklärung dafür bietet, warum das Verhalten unangemessen war. Eine öffentliche
+Entschuldigung kann verlangt werden.
 
 ### 2. Verwarnung
 

--- a/content/version/2/0/code_of_conduct.de.md
+++ b/content/version/2/0/code_of_conduct.de.md
@@ -11,12 +11,12 @@ Wir als Mitglieder, Teilnehmende und Verantwortliche unserer Gemeinschaft
 verpflichten uns bei der Teilnahme an dem Projekt und unserer Gemeinschaft zu
 einer belästigungsfreien Erfahrung für alle, unabhängig von Alter, Körpergröße,
 Behinderung, ethnischer Zuordnung, geschlechtlicher Identität und Ausdruck,
-Erfahrungsstufe, Bildung, sozialem Status, Nationalität, persönlicher
+Grad der Erfahrung, Bildung, sozialem Status, Nationalität, persönlicher
 Erscheinung, Rasse, Religion oder Geschlechtsidentität und sexueller
 Orientierung.
 
 Wir verpflichten uns, in einer Weise zu handeln und zu interagieren, die zu
-einer offenen, einladenden, vielfältigen, integrativen und gesunden Gemeinschaft
+einer offenen, einladenden, vielfältigen, inklusiven und gesunden Gemeinschaft
 beiträgt.
 
 ## Unsere Standards
@@ -63,7 +63,7 @@ Dieser Verhaltenskodex gilt für alle Gemeinschaftsbereiche und gilt auch, wenn
 eine Einzelperson die Gemeinschaft offiziell in öffentlichen Bereichen vertritt.
 Beispiele für die Repräsentation unserer Gemeinschaft sind die Verwendung einer
 offiziellen E-Mail-Adresse, das Posten über ein offizielles Social-Media-Konto
-oder das Auftreten als ernannter Vertreter bei einer Online- oder
+oder das Auftreten als ernannte Vertretung bei einer Online- oder
 Offline-Veranstaltung.
 
 ## Umsetzung

--- a/content/version/2/0/code_of_conduct.de.md
+++ b/content/version/2/0/code_of_conduct.de.md
@@ -9,7 +9,7 @@ aliases = ["/version/2/0/de"]
 
 Wir als Mitglieder, Teilnehmende und Verantwortliche unserer Gemeinschaft
 verpflichten uns bei der Teilnahme an dem Projekt und unserer Gemeinschaft zu
-einer belästigungsfreien Erfahrung für jeden, unabhängig von Alter, Körpergröße,
+einer belästigungsfreien Erfahrung für alle, unabhängig von Alter, Körpergröße,
 Behinderung, ethnischer Zuordnung, geschlechtlicher Identität und Ausdruck,
 Erfahrungsstufe, Bildung, sozialem Status, Nationalität, persönlicher
 Erscheinung, Rasse, Religion oder Geschlechtsidentität und sexueller

--- a/content/version/2/0/code_of_conduct.de.md
+++ b/content/version/2/0/code_of_conduct.de.md
@@ -12,7 +12,8 @@ verpflichten uns bei der Teilnahme an dem Projekt und unserer Gemeinschaft zu
 einer belästigungsfreien Erfahrung für jeden, unabhängig von Alter, Körpergröße,
 Behinderung, ethnischer Zuordnung, geschlechtlicher Identität und Ausdruck,
 Erfahrungsstufe, Bildung, sozialem Status, Nationalität, persönlicher
-Erscheinung, Rasse, Religion oder sexuelle Identität und Orientierung.
+Erscheinung, Rasse, Religion oder Geschlechtsidentität und sexueller
+Orientierung.
 
 Wir verpflichten uns, in einer Weise zu handeln und zu interagieren, die zu
 einer offenen, einladenden, vielfältigen, integrativen und gesunden Gemeinschaft
@@ -24,7 +25,7 @@ Beispiele für Verhaltensweisen, die zu einem positiven Umfeld für unsere
 Gemeinschaft beitragen, sind:
 
 - Einfühlungsvermögen und Freundlichkeit gegenüber anderen Menschen zeigen
-- Respekt vor unterschiedlichen Meinungen, Standpunkten und Erfahrungen
+- Unterschiedliche Meinungen, Standpunkte und Erfahrungen respektieren
 - Konstruktives Feedback geben und würdevoll annehmen
 - Verantwortung übernehmen und uns bei denjenigen entschuldigen, die von unseren
   Fehlern betroffen sind, und aus den Erfahrungen lernen
@@ -53,8 +54,8 @@ unangemessen, bedrohlich oder beleidigend halten, zu reagieren.
 Die Gemeinschaftsleiter haben das Recht und die Verantwortung Kommentare,
 Commits, Code, Wiki-Bearbeitungen, Support-Tickets und andere Beiträge, die
 nicht mit diesem Verhaltenskodex vereinbar sind zu entfernen, zu bearbeiten oder
-abzulehnen, und wird die Gründe für eine Mäßigung mitteilen Entscheidungen, wenn
-es angebracht ist.
+abzulehnen, und wird die Gründe für eine Mäßigung mitteilen, wenn es angebracht
+ist.
 
 ## Geltungsbereich
 
@@ -69,11 +70,11 @@ Offline-Veranstaltung.
 
 Fälle von missbräuchlichem, belästigendem oder anderweitig inakzeptablem
 Verhalten können unter [KONTAKTMETHODE EINFÜGEN] den für die Durchsetzung
-zuständigen Gemeinschaftsleiter gemeldet werden. Alle Beschwerden werden zeitnah
-und fair geprüft und ermittelt.
+zuständigen Gemeinschaftsleitern gemeldet werden. Alle Beschwerden werden
+zeitnah und fair geprüft und ermittelt.
 
-Alle Gemeinschaftsleiter sind verpflichtet, die Privatsphäre und Sicherheit des
-Berichterstatters eines Vorfalls zu respektieren.
+Alle Gemeinschaftsleiter sind verpflichtet, die Privatsphäre und Sicherheit
+desjenigen, der einen Vorfall gemeldet hat, zu respektieren.
 
 ## Durchsetzungsrichtlinien
 

--- a/content/version/2/0/code_of_conduct.de.md
+++ b/content/version/2/0/code_of_conduct.de.md
@@ -1,0 +1,136 @@
++++
+version = "2.0"
+aliases = ["/version/2/0/de"]
++++
+
+# Vereinbarung über Verhaltenskodex für Mitwirkende
+
+## Unsere Verpflichtung
+
+Wir als Mitglieder, Teilnehmer und Verantwortliche unserer Gemeinschaft
+verpflichten uns bei der Teilnahme an dem Projekt und unserer Gemeinschaft zu
+einer belästigungsfreien Erfahrung für jeden, unabhängig von Alter, Körpergröße,
+Behinderung, ethnischer Zuordnung, geschlechtlicher Identität und Ausdruck,
+Erfahrungsstufe, Bildung, sozialem Status, Nationalität, persönlicher
+Erscheinung, Rasse, Religion oder sexuelle Identität und Orientierung.
+
+Wir verpflichten uns, in einer Weise zu handeln und zu interagieren, die zu
+einer offenen, einladenden, vielfältigen, integrativen und gesunden Gemeinschaft
+beiträgt.
+
+## Unsere Standards
+
+Beispiele für Verhaltensweisen, die zu einem positiven Umfeld für unsere
+Gemeinschaft beitragen, sind:
+
+- Einfühlungsvermögen und Freundlichkeit gegenüber anderen Menschen zeigen
+- Respekt vor unterschiedlichen Meinungen, Standpunkten und Erfahrungen
+- Konstruktives Feedback geben und würdevoll annehmen
+- Verantwortung übernehmen und uns bei denjenigen entschuldigen, die von unseren
+  Fehlern betroffen sind, und aus den Erfahrungen lernen
+- Konzentration auf das, was nicht nur für uns als Individuen, sondern für die
+  gesamte Gemeinschaft das Beste ist
+
+Beispiele für inakzeptables Verhalten sind:
+
+- Die Verwendung sexualisierter Sprache, Bilder oder Symbolik sowie unerwünschte
+  Versuche sexueller Anbahnung
+- Beleidigende oder abwertende Kommentare, persönliche oder politische Angriffe,
+  Nutzung des Internets für unbilliges Verhalten
+- Öffentliche oder private Belästigungen
+- Das Veröffentlichen von privaten Informationen Anderer, wie zum Beispiel
+  physische oder elektronische Adressen, ohne deren ausdrückliche Erlaubnis
+- Anderes Verhalten, welches in einem professionellen Umfeld begründet als
+  unangemessen betrachtet werden kann
+
+## Verantwortlichkeiten bei der Durchsetzung
+
+Die Gemeinschaftsleiter sind verantwortlich dafür, unsere Standards für ein
+akzeptables Benehmen klarzustellen und werden angemessen und fair
+korrigierende Maßnahmen ergreifen um auf jegliches Verhalten, das sie für
+unangemessen, bedrohlich oder beleidigend halten, zu reagieren.
+
+Die Gemeinschaftsleiter haben das Recht und die Verantwortung Kommentare,
+Commits, Code, Wiki-Bearbeitungen, Support-Tickets und andere Beiträge, die
+nicht mit diesem Verhaltenskodex vereinbar sind zu entfernen, zu bearbeiten oder
+abzulehnen, und wird die Gründe für eine Mäßigung mitteilen Entscheidungen, wenn
+es angebracht ist.
+
+## Geltungsbereich
+
+Dieser Verhaltenskodex gilt für alle Gemeinschaftsbereiche und gilt auch, wenn
+eine Einzelperson die Gemeinschaft offiziell in öffentlichen Bereichen vertritt.
+Beispiele für die Repräsentation unserer Gemeinschaft sind die Verwendung einer
+offiziellen E-Mail-Adresse, das Posten über ein offizielles Social-Media-Konto
+oder das Auftreten als ernannter Vertreter bei einer Online- oder
+Offline-Veranstaltung.
+
+## Umsetzung
+
+Fälle von missbräuchlichem, belästigendem oder anderweitig inakzeptablem
+Verhalten können unter [KONTAKTMETHODE EINFÜGEN] den für die Durchsetzung
+zuständigen Gemeinschaftsleiter gemeldet werden. Alle Beschwerden werden zeitnah
+und fair geprüft und ermittelt.
+
+Alle Gemeinschaftsleiter sind verpflichtet, die Privatsphäre und Sicherheit des
+Berichterstatters eines Vorfalls zu respektieren.
+
+## Durchsetzungsrichtlinien
+
+Die Gemeinschaftsleiter werden sich bei der Bestimmung der Konsequenzen für jede
+Handlung, die ihrer Ansicht nach gegen diesen Verhaltenskodex verstößt, an diese
+Richtlinien über die Auswirkungen in der Gemeinschaft halten:
+
+### 1. Berichtigung
+
+**Auswirkungen in der Gemeinschaft**: Verwendung unangemessener Sprache oder
+anderes Verhalten, das in der Gemeinschaft als unprofessionell oder unwillkommen
+gilt.
+
+**Folge**: Eine private, schriftliche Verwarnung von den Gemeinschaftsleitern,
+die Klarheit über die Art des Verstoßes und eine Erklärung dafür bietet, warum
+das Verhalten unangemessen war. Eine öffentliche Entschuldigung kann verlangt
+werden.
+
+### 2. Verwarnung
+
+**Auswirkungen in der Gemeinschaft**: Eine Verletzung durch einen einzelnen
+Vorfall oder eine Reihe von Handlungen.
+
+**Folge**: Eine Warnung mit Konsequenzen bei wiederholtem Fehlverhalten. Keine
+Interaktion mit den beteiligten Personen, einschließlich unaufgeforderter
+Interaktion mit denjenigen, die den Verhaltenskodex durchsetzen, für einen
+bestimmten Zeitraum. Dazu gehört die Vermeidung von Interaktionen in
+Gemeinschaftsräumen sowie in externen Kanälen wie sozialen Medien. Ein Verstoß
+gegen diese Bedingungen kann zu einem vorübergehenden oder dauerhaften Verbot
+führen.
+
+### 3. Vorübergehender Ausschluss
+
+**Auswirkungen in der Gemeinschaft**: Eine schwerwiegende Verletzung von
+Gemeinschaftsstandards, einschließlich anhaltend unangemessenen Verhaltens.
+
+**Folge**: Ein zeitlich begrenztes Verbot jeglicher Art von Interaktion oder
+öffentlicher Kommunikation mit der Gemeinschaft. Während dieses Zeitraums ist
+keine öffentliche oder private Interaktion mit den beteiligten Personen erlaubt.
+Auch keine unaufgeforderte Interaktion mit denjenigen, die den Verhaltenskodex
+durchsetzen. Ein Verstoß gegen diese Bedingungen kann zu einem dauerhaften
+Verbot führen.
+
+### 4. Dauerhafter Ausschluss
+
+**Auswirkungen in der Gemeinschaft**: Aufzeigen eines Musters von Verletzungen
+der Gemeinschaftsstandards, einschließlich anhaltend unangemessenen Verhaltens,
+Belästigung einer Person oder Aggression gegen oder Herabsetzung von Gruppen von
+Personen.
+
+**Folge**: Ein dauerhaftes Verbot jeglicher Art von öffentlicher Interaktion
+innerhalb der Gemeinschaft.
+
+## Bezug
+
+Dieser Verhaltenskodex basiert auf dem [Contributor Covenant][homepage],
+Version 2.0, verfügbar unter
+<https://www.contributor-covenant.org/de/version/2/0/code-of-conduct>
+
+[homepage]: https://www.contributor-covenant.org


### PR DESCRIPTION
This is the translation of the Code of Conduct into German.
I have tried to use version 1.4 as a reference to keep the differences as small as possible.