### PR TITLE
Add BcnEng to the adopters.csv list

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -21,6 +21,7 @@ AVA, https://github.com/avajs/ava
 Babel, https://github.com/babel/babel
 Baleen CLI, https://github.com/baleen/cli
 Baleen Migrations, https://github.com/baleen/migrations
+BcnEng, https://bcneng.org
 Begynner, https://github.com/marcker/begynner
 Bionode, https://www.bionode.io/
 BioSigKit, https://github.com/hooman650/BioSigKit


### PR DESCRIPTION
Adding https://bcneng.org to `adopters.csv` file