### PR TITLE
Add GlobaLeaks project to adopters

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -101,6 +101,7 @@ Git for Windows, https://github.com/git-for-windows
 GitLab, https://gitlab.com/gitlab-org/gitlab-foss/
 Giveth, https://wiki.giveth.io/policy/codeofconduct/
 Glimpse, https://glimpse-editor.org
+GlobaLeaks, https://github.com/globaleaks/GlobaLeaks
 GNSS-SDR, https://github.com/gnss-sdr/gnss-sdr
 GNU Guix and GuixSD, https://guix.gnu.org/
 Golang, https://golang.org/conduct


### PR DESCRIPTION
Added GlobaLeaks: https://github.com/globaleaks/GlobaLeaks/blob/main/CODE_OF_CONDUCT.md
![Screenshot_2021-01-25 globaleaks GlobaLeaks](https://user-images.githubusercontent.com/217034/105709401-f556f200-5f15-11eb-9ff1-42c393a44ac3.png)
