### PR TITLE
Add Andalusian Spanish translation (v2.0) plus AndaluGeeks as adopter

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -78,6 +78,10 @@ languageCode = "el"
 languageName = "Español"
 languageCode = "es"
 
+[Languages.es-AND]
+languageName = "Andalûh EPA"
+languageCode = "es-and"
+
 [Languages.fr]
 languageName = "Français"
 languageCode = "fr"

--- a/content/version/2/0/code_of_conduct.es-and.md
+++ b/content/version/2/0/code_of_conduct.es-and.md
@@ -1,0 +1,89 @@
++++
+version = "2.0"
+aliases = ["/version/2/0/es"]
++++
+
+# Código de Condûtta combenío pa Contribuyentê
+
+## Nuêttro compromiço
+
+Noçotrô, como miembrô, contribuyentê y âmminîttradorê nô comprometemô a açêh de la partiçipaçión en nuêttra comunidá una êpperiençia libre de acoço pa tó er mundo, independientemente de la edá, dimençión corporâh, minûbbalía biçible o imbiçible, ênniçidá, carâtterítticâ çêççualê, identidá y êppreçión de hénero, nibêh de êpperiençia, educaçión, nibêh çoçio-económico, naçionalidá, apariençia perçonâh, raça, relihión, o identidá u orientaçión çêççuâh.
+
+Nô comprometemô a âttuâh e interâttuâh de manerâ que contribuyan a una comunidá abierta, acohedora, diberça, incluçiba y çana.
+
+## Nuêttrô êttándarê
+
+Ehemplô de comportamiento que contribuyen a creâh un ambiente poçitibo pa nuêttra comunidá:
+
+* Demôttrâh empatía y amabilidá ante otrâ perçonâ
+* Rêppeto a diferentê opinionê, puntô de bîtta y êpperiençiâ
+* Dâh y açêttâh adecuadamente retroalimentaçión côttrûttiba
+* Açêttâh la rêpponçabilidá y dîccurparçe ante quienê çe bean afêttáô por nuêttrô errorê, aprendiendo de la êpperiençia
+* Çentrarçe en lo que çea mehôh no çólo pa noçotrô como indibiduô, çino pa la comunidá en henerâh
+
+Ehemplô de comportamiento inaçêttable:
+
+* El uço de lenguahe o imáhenê çêççualiçâh, y aprôççimaçionê o
+  atençionê çêççualê de cuarquiêh tipo
+* Comentariô dêppêttibô (_trolling_), inçurtantê o derogatoriô, y ataquê perçonalê o políticô
+* El acoço en público o pribao
+* Publicâh informaçión pribá de otrâ perçonâ, talê como dirêççionê fíçicâ o de correo
+  elêttrónico, çin çu permiço êpplíçito
+* Otrâ condûttâ que puedan çêh raçonablemente conçiderâh como inapropiâh en un
+  entônno profeçionâh
+
+## Aplicaçión de lâ rêpponçabilidadê
+
+Lô âmminîttradorê de la comunidá çon rêpponçablê de aclarâh y açêh cumplîh nuêttrô êttándarê de comportamiento açêttable y tomarán âççionê apropiâh y corrêttibâ de forma hûtta en rêppuêtta a cuarquiêh comportamiento que conçideren inapropiao, amenaçante, ofençibo o dañino.
+
+Lô âmminîttradorê de la comunidá tendrán er derexo y la rêpponçabilidá de eliminâh, editâh o rexaçâh comentariô, _commits_, código, ediçionê de páhinâ de wiki, _issues_ y otrâ contribuçionê que no çe alineen con êtte Código de Condûtta, y comunicarán lâ raçonê pa çû deçiçionê de moderaçión cuando çea apropiao.
+
+## Arcançe
+
+Êtte código de condûtta aplica tanto a êppaçiô der proyêtto como a êppaçiô públicô donde un indibiduo êtté en repreçentaçión der proyêtto o comunidá. Ehemplô de êtto incluyen el uço de la cuenta ofiçiâh de correo elêttrónico, publicaçionê a trabêh de lâ redê çoçialê ofiçialê, o preçentaçionê con perçonâ deçînnâh en ebentô en línea o no.
+
+## Aplicaçión
+
+Îttançiâ de comportamiento abuçibo, acoçadôh o inaçêttable de otro modo podrán çêh reportâh a lô âmminîttradorê de la comunidá rêpponçablê der cumplimiento a trabêh de [INÇERTÂH MÉTODO DE CONTÂTTO]. Toâ lâ quehâ çerán ebaluâh e imbêttigâh de una manera puntuâh y hûtta.
+
+Tôh lô âmminîttradorê de la comunidá êttán obligáô a rêppetâh la pribaçidá y la çeguridá de quienê reporten inçidentê.
+
+## Gíâ de Aplicaçión
+
+Lô âmminîttradorê de la comunidá çegirán êttâ Gíâ de Impâtto en la Comunidá pa determinâh lâ conçecuençiâ de cuarquiêh âççión que hûggen como un incumplimiento de êtte Código de Condûtta:
+
+### 1. Corrêççión
+
+**Impâtto en la Comunidá**: El uço de lenguahe inapropiao u otro comportamiento conçiderao no profeçionâh o no acohedôh en la comunidá.
+
+**Conçecuençia**: Un abiço êccrito y pribao por parte de lô âmminîttradorê de la comunidá, proporçionando claridá arrededôh de la naturaleça de êtte incumplimiento y una êpplicaçión de por qué er comportamiento ê inaçêttable. Una dîccurpa pública podría çêh çoliçitá.
+
+### 2. Abiço
+
+**Impâtto en la Comunidá**: Un incumplimiento cauçao por un único inçidente o por una cadena de âççionê.
+
+**Conçecuençia**: Un abiço con conçecuençiâ por comportamiento prolongao. No çe interâttúa con lâ perçonâ imbolucrâh, incluyendo interâççión no çoliçitá con quienê çe encuentran aplicando el Código de Condûtta, por un periodo êppeçificao de tiempo. Êtto incluye ebitâh lâ interâççionê en êppaçiô de la comunidá, açí como a trabêh de canalê êttênnô como lâ redê çoçialê. Incumplîh êttô términô puede conduçîh a una êppurçión temporâh o permanente.
+
+### 3. Êppurçión temporâh
+
+**Impâtto en la Comunidá**: Una çerie de incumplimientô de lô êttándarê de la comunidá, incluyendo comportamiento inapropiao continuo.
+
+**Conçecuençia**: Una êppurçión temporâh de cuarquiêh forma de interâççión o comunicaçión pública con la comunidá durante un interbalo de tiempo êppeçificao. No çe permite interâttuâh de manera pública o pribá con lâ perçonâ imbolucrâh, incluyendo interâççionê no çoliçitâh con quienê çe encuentran aplicando el Código de Condûtta, durante êtte periodo. Incumplîh êttô términô puede conduçîh a una êppurçión permanente.
+
+### 4. Êppurçión permanente
+
+**Impâtto en la Comunidá**: Demôttrâh un patrón çîttemático de incumplimientô de lô êttándarê de la comunidá, incluyendo condûttâ inapropiâh prolongâh en er tiempo, acoço de indibiduô, o agreçionê o menôppreçio a grupô de indibiduô.
+
+**Conçecuençia**: Una êppurçión permanente de cuarquiêh tipo de interâççión pública con la comunidá der proyêtto.
+
+## Atribuçión
+
+Êtte Código de Condûtta ê una adâttaçión del [Contributor Covenant][homepage], berçión 2.0,
+dîpponible en https://www.contributor-covenant.org/es/version/2/0/code_of_conduct.html
+
+Lâ Gíâ de Impâtto en la Comunidá êttán îppirâh en la [êccalera de aplicaçión der código de condûtta de Mozilla](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+Pa rêppuêttâ a lâ preguntâ frecuentê de êtte código de condûtta, conçurta lâ FAQ en
+https://www.contributor-covenant.org/faq. Ay tradûççionê dîpponiblê en https://www.contributor-covenant.org/translations

--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -10,6 +10,7 @@ Algorrent, https://github.com/algorrent/algorrent
 All Algorithms, https://github.com/AllAlgorithms/algorithms
 Airbnb, https://airbnb.io/codeofconduct/
 Amsterdam.rb, https://amsrb.org/code-of-conduct/
+AndaluGeeks, https://andaluh.es/covenant-codigo-condutta/
 Android IMSI-Catcher Detector, https://github.com/CellularPrivacy/Android-IMSI-Catcher-Detector
 angular-formly, https://github.com/formly-js/angular-formly
 AngularJS, https://github.com/angular/code-of-conduct


### PR DESCRIPTION
Hi, my name is José Félix Ontañón and I’m speaking in behalf of the [AndaluGeeks](https://andaluh.es) team, a #freesoftware #opensource community formed by both linguists and developers, to promote the Andalusian Spanish dialect. We believe digital tools are the best way to support language learning. Check out our [github repos](https://github.com/andalugeeks).

We've recently adopted Contributor Covenant as the Code of Conduct for our users (Telegram) and developers (Slack) online communities. Find here a link to the Code of Conduct in [Spanish](https://andaluh.es/covenant-codigo-conducta) and [Andalusian Spanish](https://andaluh.es/covenant-codigo-condutta).

**We're submitting this pull request to:**

:arrow_right: Contribute with our andalusian translation.
:arrow_right: Add ourselves as adopters to your file.

_**About AndaluGeeks**_

We work, for non-profit reasons, in developing tools to assist in Andalusian learning. We’ve already developed an automatic [spanish to andaluz translator](https://andaluh.es/transcriptor), a [mobile virtual keyboard](https://andaluh.es/teclao-andaluh) to write andalusian (with predictive text) and non-official [Wikipedia Andaluh](https://wiki.andaluh.es) (AndaluWiki). We’ve also translated [Minecraft to Andaluz](https://andaluh.es/minecraft-andaluh), which has been already accepted as an official language by Mojang (the company behind Minecraft).

_**About Andalusian Spanish Dialect**_

[Andalusian Spanish](https://en.wikipedia.org/wiki/Andalusian_Spanish) is a language spoken by 9 million inhabitants between the regions of Andalusia, Ceuta and Melilla, as well as in some areas of the province of Badajoz, or Gibraltar. Popular spanish writers have already written in andalusian as Juan Ramón Jiménez (Nobel Prize in Literature). See a summary of [200 writers in this book](https://www.academia.edu/41658317/La_literatura_en_andaluz_La_representaci%C3%B3n_gr%C3%A1fica_del_andaluz_en_los_textos_literarios).

Writing in Andalusian is currently enjoying a great impact thanks to the [Andalusian Proposal EPA](https://andaluhepa.wordpress.com/acerca-de) (acronym for Standard for Andaluz). This has offered a precise set of spelling rules for writing in Andalusian, and is being [used in song lyrics, poetry, literature, blogs and social networks](http://us20.campaign-archive.com/?u=e1cbee1c34a2033ce0ecbc155&id=06d1977f69). AndaluGeeks supports this set of spelling rules and we develop all our tools to promote it.