### PR TITLE
Add Grav CMS to the adopters list

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -109,9 +109,9 @@ Golden Cobra, https://github.com/ikuseiGmbH/Goldencobra
 Google, https://opensource.google/docs/releasing/template/CODE_OF_CONDUCT/
 GorangoCSS, https://gorangocss.kawanua.id/codeofconduct/
 GoReleaser, https://github.com/goreleaser/goreleaser
-Grav CMS, https://getgrav.org
-Gremlins tracker for Visual Studio Code, https://github.com/nhoizey/vscode-gremlins
 Grape, https://github.com/ruby-grape/grape
+Grav CMS, https://github.com/getgrav/grav
+Gremlins tracker for Visual Studio Code, https://github.com/nhoizey/vscode-gremlins
 Growing Devs, https://github.com/growingdevs/growingdevs.github.io
 Hacken.in, https://github.com/hacken-in/hacken-in
 Hanami, http://hanamirb.org/community/#code-of-conduct

--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -109,6 +109,7 @@ Golden Cobra, https://github.com/ikuseiGmbH/Goldencobra
 Google, https://opensource.google/docs/releasing/template/CODE_OF_CONDUCT/
 GorangoCSS, https://gorangocss.kawanua.id/codeofconduct/
 GoReleaser, https://github.com/goreleaser/goreleaser
+Grav CMS, https://getgrav.org
 Gremlins tracker for Visual Studio Code, https://github.com/nhoizey/vscode-gremlins
 Grape, https://github.com/ruby-grape/grape
 Growing Devs, https://github.com/growingdevs/growingdevs.github.io


### PR DESCRIPTION
We have been adopters of the Contributor Covenant for over 4 years and as I am updating to v2 I just realize now there was a list of adopters we could have been proudly part of. 😄 

Thank you for this project!


> Note: I have also took the liberty to fix an alphabetical order issue