### PR TITLE
Add Pottery to list of adopters

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -206,6 +206,7 @@ Pixi.js Haxe Externs, https://github.com/pixijs/pixi-haxe
 Playscii, http://vectorpoem.com/playscii/
 pmap, https://github.com/bruceadams/pmap
 postcss-glitch, https://github.com/crftd/postcss-glitch
+Pottery, https://github.com/brainix/pottery
 prance (Resolving Swagger/OpenAPI 2.0 Parser), https://github.com/jfinkhaeuser/prance
 PRAW, https://github.com/praw-dev/praw
 Pre-filled repository, https://github.com/GuglielmoPepe/pre-filled-repository


### PR DESCRIPTION
Hello, folks!

I&rsquo;d love to add my project, Pottery, to the list of adopters. Here&rsquo;s a link to [Pottery&rsquo;s Contributor Covenant](https://github.com/brainix/pottery/blob/master/CODE_OF_CONDUCT.md).

Thanks,
Raj