### PR TITLE
A universal approach to end all discrimination

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,15 +3,9 @@
 
 ## Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in our
-community a harassment-free experience for everyone, regardless of age, body
-size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, religion, or sexual identity
-and orientation.
+We as members, contributors, and leaders pledge to make participation in our community a harassment and discrimination-free experience for everyone, regardless of age, body size, visible or invisible disability, health, national, ethnic or social origin, sex characteristics, gender identity and expression, level of experience, education, language, profession, citizenship, immigration status, origin, place of birth or residence, property or socio-economic status, criminal records, marital status, family status, pregnancy, nationality, personal appearance, race, caste, color, religion or belief, sexual identity and orientation, political or other opinions, social identity, membership in a social group, or any characteristics other than that of individual merit.
 
-We pledge to act and interact in ways that contribute to an open, welcoming,
-diverse, inclusive, and healthy community.
+We pledge to act and interact in ways that do not contribute to systemic biases, but instead contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
 ## Our Standards
 


### PR DESCRIPTION
Hi,

I recently learned that the new version of Contributor Covenant is under development. I really like Covenant and all the ideas behind it. Might I make a suggestion? I reworded things a bit and added more protected classes. Here's my version of the first two paragraphs:

“We as members, contributors, and leaders pledge to make participation in our community a harassment and discrimination-free experience for everyone, regardless of age, body size, visible or invisible disability, health, national, ethnic or social origin, sex characteristics, gender identity and expression, level of experience, education, language, profession, citizenship, immigration status, origin, place of birth or residence, property or socio-economic status, criminal records, marital status, family status, pregnancy, nationality, personal appearance, race, caste, color, religion or belief, sexual identity and orientation, political or other opinions, social identity, membership in a social group, or any characteristics other than that of individual merit.

We pledge to act and interact in ways that do not contribute to systemic biases, but instead contribute to an open, welcoming, diverse, inclusive, and healthy community.”

Why do I think it's important? In my opinion the current Covenant is leaving way too much space for discrimination. For example, people with health or mental health issues are still stigmatized, a lot of those with criminal records are PoC, and not only they are stigmatized, they're also often denied basic rights. Another group experiencing prejudice are immigrants. They are being discriminated against just because of their origin or accent or because they come from a different culture.

I know the list is long, that’s why I added “social identity” and “membership in a social group.” This encompasses everyone who belongs to any stigmatized group. I think the list can be shortened if these two protected classes remain.

On merit. You hear it often from the proponents of meritocracy, how nothing but the code itself should matter. And I agree with them. Person’s gender, race, sexuality, etc. should not be a deciding factor on whether or not they can be a member of the community. Basically what it says is that you can’t discriminate against a person for any reasons other than their professional behavior or quality of their work. I think no proponent of meritocracy will be able to argue with that.

And finally, I think it’s very important to acknowledge and fight systemic biases. These biases are very pervasive and I believe we all should do our best to end them. 

Generally speaking, discrimination can be based on reasons that are arbitrary and superficial (unrelated to job and professionalism), stigmatizing (demeaning or subordinating
based on identity), stereotyping (making assumptions about roles and competences based on group status) or reasons that are rooted in systemic biases (i.e. reasons that contribute to inequality, social segregation and hierarchy, or limit the opportunities of affected individuals) [see Jessica A. Clarke, Against Immutability, 125 Yale L. J. 2, 2015]. Instead of trying to list every protected class (which I kinda did), we can focus on the reasons behind discrimination, and try to prohibit them. For example, a sex worker, although not listed, is still a protected class because discriminating them falls under “membership in a social group” (sex workers are a stigmatized group), “contributing to systemic bias” (often sex workers are denied equal opportunities and mistreated) and “merit” (sex work is unrelated to their ability to code).

You might think that my proposal is way too radical. And that’s ok. My goal here is to give you some suggestions and start a conversation.

I really hope this will be somewhat useful.