### PR TITLE
Ask for tolerance, not respect

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -19,7 +19,7 @@ Examples of behavior that contributes to a positive environment for our
 community include:
 
 * Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
+* Being tolerant of differing opinions, viewpoints, and experiences
 * Giving and gracefully accepting constructive feedback
 * Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience


### PR DESCRIPTION
Respect cannot be manufactured at will. If you don't respect an idea
(for example that the Earth is flat), then it doesn't matter how hard
you try; you still will not respect it. In that sense respect is like
belief; nobody can force you to believe the Moon is made of cheese.
Either you do or you don't.

You can pretend to believe in something, and you can pretend to respect
something, but you really don't. Any policy that asks people to pretend
is not a good policy.

The commitment should be towards tolerance; which can be honestly given,
not respect; which can only be faked.

A nuanced debate over tolerance versus respect can be seen in the
proposal at Cambridge University to demand respect. Tolerance won.

Fixes #892.

Signed-off-by: Felipe Contreras <felipe.contreras@gmail.com>