### PR TITLE
Add SquirrelJME to adopters.csv

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -268,6 +268,7 @@ Spree, https://github.com/spree/spree
 Spring Boot, https://github.com/spring-projects/spring-boot
 Spring, https://github.com/spring-projects
 Squirrel for Windows, https://github.com/squirrel/squirrel.windows
+SquirrelJME, https://squirreljme.cc/
 Stack.io, https://github.com/germanstack
 Storybook, https://github.com/storybookjs/storybook
 Styled Hooks, https://github.com/colingourlay/styled-hooks


### PR DESCRIPTION
Hi!

This adds SquirrelJME, which uses the Contributor Code of Conduct: <https://squirreljme.cc/doc/tip/code-of-conduct.mkd>.

The file exists within the repository along with being linked by the main documentation:

![image](https://user-images.githubusercontent.com/11927855/129800879-ae9a8e54-ca22-43c2-837b-960718dad3d3.png)
