### PR TITLE
Add JSON Schema to list of adopters

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -144,6 +144,7 @@ Johnny-Five, https://github.com/rwaldron/johnny-five
 Jolie, https://jolie-lang.org/
 JRuby Gradle, https://github.com/jruby-gradle/jruby-gradle-plugin
 JRuby, https://github.com/jruby/jruby/
+JSON Schema, https://github.com/json-schema-org/json-schema-spec
 JuneteenthConf, https://juneteenthconf.com/
 json-rpc, https://github.com/pavlov99/json-rpc
 Kickoff, https://github.com/TryKickoff/kickoff/

--- a/static/featured-adopters.csv
+++ b/static/featured-adopters.csv
@@ -28,6 +28,7 @@ Intel OTC, https://01.org/blogs/2018/intel-covenant-code
 Jekyll, https://github.com/jekyll/jekyll
 Jenkins, https://www.jenkins.io/conduct/
 JRuby, https://github.com/jruby/jruby/
+JSON Schema, https://github.com/json-schema-org/json-schema-spec
 JuneteenthConf, https://juneteenthconf.com/
 Hanami, http://hanamirb.org/community/#code-of-conduct
 Kong, https://github.com/Kong/kong/


### PR DESCRIPTION
The CoC itself can be found in our `.github` repo, which is picked up by GitHub and used in the UI across all org owned repos.

Additionally, the badge in the linked repo readme links to the CoC for our org.