### PR TITLE
Add dxw as an adopter

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -87,6 +87,7 @@ Dokku, https://github.com/dokku/dokku
 Doublify, https://github.com/doublify
 Drachenhorn, https://github.com/Drachenhorn-Team/Drachenhorn
 Dracut, https://github.com/dracutdevs/dracut
+dxw, https://www.dxw.com
 ECB Exchange, https://github.com/matthutchinson/ecb_exchange
 Eclipse Che, https://github.com/eclipse/che
 Eclipse, https://www.eclipse.org/


### PR DESCRIPTION
[dxw](https://www.dxw.com) have adopted the CC for all our code. See https://github.com/dxw/.github/blob/main/CODE_OF_CONDUCT.md and https://github.com/dxw/tech-team-rfcs/blob/main/rfc-028-adopt-a-code-of-conduct.md