### PR TITLE
Add Sovereign Cloud Stack to list of adopters

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -291,6 +291,7 @@ Snuffle, https://gitlab.com/coraline/snuffle/tree/master
 Sonobuoy, https://github.com/vmware-tanzu/sonobuoy
 Software Carpentry, https://github.com/swcarpentry
 Software Foundations Chinese Translation, https://github.com/Coq-zh/SF-zh
+Sovereign Cloud Stack, https://github.com/SovereignCloudStack/Docs/
 SOULs, https://github.com/elsoul/souls
 SPIP, https://www.spip.net/fr_rubrique91.html
 Spree, https://github.com/spree/spree


### PR DESCRIPTION
We recently adopted many parts of the Contributor Covenant: https://github.com/SovereignCloudStack/Docs/blob/main/CODE-OF-CONDUCT.md

Signed-off-by: Eduard Itrich <eduard@itrich.net>