### PR TITLE
Add Bootstrap as an adopter

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -33,6 +33,7 @@ Begynner, https://github.com/marcker/begynner
 Bionode, https://www.bionode.io/
 BioSigKit, https://github.com/hooman650/BioSigKit
 bitmath, https://github.com/tbielawa/bitmath/
+Bootstrap, https://github.com/twbs/bootstrap
 BootstrapVue, https://github.com/bootstrap-vue/bootstrap-vue
 BoxBilling, https://boxbilling.org/
 Bridge.NET, https://bridge.net/


### PR DESCRIPTION
Hello there :wave: 
Recently updated our Contributor Covenant Code of Conduct from 1.4 to v2.1 and we realized we never created a PR to add us as adopters :)
Here it is, thank you for you work!

### [Link to our Code of Conduct file](https://github.com/twbs/bootstrap/blob/main/CODE_OF_CONDUCT.md)