### PR TITLE
Add initial Swedish translation of v2.1

### DIFF
--- a/content/version/2/1/code_of_conduct.sv.md
+++ b/content/version/2/1/code_of_conduct.sv.md
@@ -3,73 +3,64 @@ version = "2.1"
 aliases = ["/version/2/1/sv"]
 +++
 
-# Gemenskapens uppförandekod för bidrag
+# Gemenskapens uppförandekod vid bidrag
 
 ## Vårt löfte
-
 Vi som medlemmar, bidragsgivare och ledare lovar att göra deltagandet i vår
-gemenskap fri från trakasserier för alla, oavsett ålder, kropp
-storlek, synligt eller osynligt funktionshinder, etnicitet, könsegenskaper, könsidentitet, erfarenhetsnivå, utbildning, socioekonomisk status,
+gemenskap fri från trakasserier och för alla oavsett ålder, kropp,
+storlek, funktionsnedsättning, etnicitet, könsegenskaper, könsidentitet, erfarenhetsnivå, utbildning, socioekonomisk status,
 nationalitet, personligt utseende, ras, kast, färg, religion eller sexuell
 identitet och inriktning.
 
 Vi lovar att agera och interagera på ett sätt som bidrar till en öppen, välkomnande,
-inkluderande och hälsosam gemenskap rik på mångfald.
+inkluderande och trygg gemenskap rik på mångfald.
 
 ## Våra standarder
-
 Några exempel på beteenden som bidrar till en positiv miljö för
 gemenskapen:
 
-* Att visa empati och vänlighet mot andra människor
-* Att visa respekt för olika åsikter, synsätt och erfarenheter
-* Att tacksamt ge och ta emot konstruktiv återkoppling
+* Att visa empati och vänlighet mot andra människor.
+* Att visa respekt för olika åsikter, synsätt och erfarenheter.
+* Att tacksamt ge och ta emot konstruktiv återkoppling.
 * Att ta ansvar och att be om ursäkt till de som drabbats av våra misstag,
   och lära av erfarenheten
-* Att fokusera på det som är bäst, inte bara för oss som individer, utan för gemenskapens helhet
+* Att fokusera på det som är bäst, inte bara för oss som individer, utan för gemenskapens helhet.
 
-Några exempel på oacceptabelt beteende:
+Några exempel på beteenden som inte är acceptabelt:
+* Användning av sexualiserat språk eller bildspråk, samt sexuella närmanden eller anspråk.
+* Trollande, förolämpande och nedsättande kommentarer, personliga eller politiska attacker.
+* Offentliga eller privata trakasserier.
+* Att utan lov publicera andras privata information, såsom en fysisk adress eller e-postadress.
+* Annat beteende som rimligen kan anses vara olämpligt i en professionell miljö.
 
-* Användning av sexualiserat språk eller bildspråk, samt sexuella närmanden eller anspråk
-* Trollande, förolämpande och nedsättande kommentarer, personliga eller politiska attacker
-* Offentliga eller privata trakasserier
-* Att utan lov publicera andras privata information, såsom en fysisk adress eller e-postadress
-* Annat beteende som rimligen kan anses vara olämpligt i en professionell miljö
-
-## Tillämpningsansvar
-
+## Ansvar för tillämpning
 Gemenskapens ledare är ansvariga för att klargöra och upprätthålla våra standarder för ett acceptabelt beteende och kommer att vidta lämpliga och rättvisa tillrättavisande åtgärder som svar på beteenden som de anser vara olämpliga, hotfulla, stötande, eller skadliga.
 
 Gemenskapens ledare har rätt och ansvar att ta bort, redigera eller avvisa
-kommentarer, commit, kod, wiki-redigeringar, frågor och andra bidrag som är
-inte uppfyller denna uppförandekod, och kommer att berätta om vilka skäl för modereringen var när så är lämpligt.
+kommentarer, commit, kod, wiki-redigeringar, frågor och andra bidrag som
+inte följer denna uppförandekod. Gemenskapens ledare kommer att informera om skäl för modereringen när så är lämpligt.
 
 ## Omfattning
-
 Denna uppförandekod gäller inom alla gemenskapsområden, även när en individ officiellt representerar gemenskapen i allmänheten.
 Exempel på att representera vår gemenskap inkluderar att använda en officiell e-postadress, att göra inlägg via ett officiellt konto på sociala medier, eller att vara en utsedd representant vid ett evenemang, oavsett om det är virtuellt eller verkligt.
 
-## Tillämpning
-
+## Tillämpning och rapportering
 Fall av kränkande, trakasserande eller på annat sätt oacceptabelt beteende
-rapporteras till ansvariga gemenskapsledare
+rapporteras till ansvariga ledare för gemenskapen
 [INFOGA KONTAKTMETOD].
 Klagomål kommer att granskas och utredas snabbt och rättvist.
 
-Alla gemenskapsledare är skyldiga att respektera rapportörens integritet och säkerhet oavsett incident.
+Alla gemenskapens ledare är skyldiga att respektera rapportörens integritet och säkerhet oavsett incident.
 
 ## Riktlinjer för tillämpning
-
-Gemenskapsledare kommer att följa dessa riktlinjer för att avgöra konsekvenserna för handlingar som de anser strider mot denna uppförandekod:
+Gemenskapens ledare kommer att följa dessa riktlinjer för att avgöra konsekvenserna för handlingar som de anser strider mot denna uppförandekod:
 
 ### 1. Rättelse
-
 **Påverkan på gemenskapen**: Användande av olämpligt språk eller annat beteende som anses vara oprofessionellt eller opassande i gemenskapen.
 
 **Konsekvens**: En privat, skriftlig varning från gemenskapsansvariga, en tydlig förklaring av överträdelsens art och till varför beteendet var olämpligt. En offentlig ursäkt kan begäras.
 
 ### 2. Varning
-
 **Påverkan på gemenskapen**: En överträdelse genom en enskild incident eller serie av
 åtgärder.
 
@@ -78,26 +69,23 @@ interaktion med de inblandade personerna, inklusive oönskad interaktion med
 de som upprätthåller uppförandekoden, under en viss tidsperiod. 
 Det inkluderar att undvika interaktioner i gemenskapsutrymmen såväl som externa kanaler som sociala medier. Överträdelse mot dessa villkor kan leda till en tillfällig eller permanent utslutning ur gemenskapen.
 
-### 3. Tillfälligt förbud
-
+### 3. Tillfälligt avstängd
 **Påverkan på gemenskapen**: En allvarlig överträdelse mot gemenskapsstandarder, inklusive ett kontinuerligt olämpligt beteende.
 
-**Konsekvens**: Ett tillfälligt förbud från någon form av interaktion eller offentlig kommunikation med gemenskapen under en viss tidsperiod.
+**Konsekvens**: En tillfällig avstängning från någon form av interaktion eller offentlig kommunikation med gemenskapen under en viss tidsperiod.
 Ingen offentlig eller privat interaktion med de inblandade personerna, inklusive oönskad interaktion
 med dem som upprätthåller uppförandekoden, tillåts under denna period.
-Överträdelse mot dessa villkor kan leda till ett permanent förbud.
+Överträdelse mot dessa villkor kan leda till en permanent avstängning.
 
-### 4. Permanent förbud
-
+### 4. Permanent avstängd
 **Påverkan på gemenskapen**: Visar ett mönster av överträdelser av gemenskapens
 riktlinjer, inklusive kontinuerligt olämpligt beteende, trakasserier av en
-individ, eller aggression eller nedvärderande av grupper av individer.
+individ, eller aggression eller nedvärderande av individ.
 
-**Konsekvens**: Ett permanent förbud för alla former av offentlig interaktion inom
+**Konsekvens**: En permanent avstängning för alla former av offentlig interaktion inom
 gemenskapen.
 
 ## Erkännanden
-
 Denna uppförandekod är en översättning av [Contributor Covenant][hemsida],
 version 2.1, tillgänglig på
 [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
@@ -105,7 +93,7 @@ version 2.1, tillgänglig på
 Uppförandekoden inspirerades av
 [Mozillas uppförandekod][Mozilla CoC].
 
-För svar på vanliga frågor kring denna uppförandekod, se "Vanliga frågor (F.A.Q)", 
+För svar på vanliga frågor kring uppförandekod, se "Vanliga frågor (F.A.Q)", 
 [https://www.contributor-covenant.org/faq][FAQ]. 
 Översättningar finns tillgängliga på
 [https://www.contributor-covenant.org/translations][translations].

--- a/content/version/2/1/code_of_conduct.sv.md
+++ b/content/version/2/1/code_of_conduct.sv.md
@@ -1,0 +1,117 @@
++++
+version = "2.1"
+aliases = ["/version/2/1/sv"]
++++
+
+# Gemenskapens uppförandekod för bidrag
+
+## Vårt löfte
+
+Vi som medlemmar, bidragsgivare och ledare lovar att göra deltagandet i vår
+gemenskap fri från trakasserier för alla, oavsett ålder, kropp
+storlek, synligt eller osynligt funktionshinder, etnicitet, könsegenskaper, könsidentitet, erfarenhetsnivå, utbildning, socioekonomisk status,
+nationalitet, personligt utseende, ras, kast, färg, religion eller sexuell
+identitet och inriktning.
+
+Vi lovar att agera och interagera på ett sätt som bidrar till en öppen, välkomnande,
+inkluderande och hälsosam gemenskap rik på mångfald.
+
+## Våra standarder
+
+Några exempel på beteenden som bidrar till en positiv miljö för
+gemenskapen:
+
+* Att visa empati och vänlighet mot andra människor
+* Att visa respekt för olika åsikter, synsätt och erfarenheter
+* Att tacksamt ge och ta emot konstruktiv återkoppling
+* Att ta ansvar och att be om ursäkt till de som drabbats av våra misstag,
+  och lära av erfarenheten
+* Att fokusera på det som är bäst, inte bara för oss som individer, utan för gemenskapens helhet
+
+Några exempel på oacceptabelt beteende:
+
+* Användning av sexualiserat språk eller bildspråk, samt sexuella närmanden eller anspråk
+* Trollande, förolämpande och nedsättande kommentarer, personliga eller politiska attacker
+* Offentliga eller privata trakasserier
+* Att utan lov publicera andras privata information, såsom en fysisk adress eller e-postadress
+* Annat beteende som rimligen kan anses vara olämpligt i en professionell miljö
+
+## Tillämpningsansvar
+
+Gemenskapens ledare är ansvariga för att klargöra och upprätthålla våra standarder för ett acceptabelt beteende och kommer att vidta lämpliga och rättvisa tillrättavisande åtgärder som svar på beteenden som de anser vara olämpliga, hotfulla, stötande, eller skadliga.
+
+Gemenskapens ledare har rätt och ansvar att ta bort, redigera eller avvisa
+kommentarer, commit, kod, wiki-redigeringar, frågor och andra bidrag som är
+inte uppfyller denna uppförandekod, och kommer att berätta om vilka skäl för modereringen var när så är lämpligt.
+
+## Omfattning
+
+Denna uppförandekod gäller inom alla gemenskapsområden, även när en individ officiellt representerar gemenskapen i allmänheten.
+Exempel på att representera vår gemenskap inkluderar att använda en officiell e-postadress, att göra inlägg via ett officiellt konto på sociala medier, eller att vara en utsedd representant vid ett evenemang, oavsett om det är virtuellt eller verkligt.
+
+## Tillämpning
+
+Fall av kränkande, trakasserande eller på annat sätt oacceptabelt beteende
+rapporteras till ansvariga gemenskapsledare
+[INFOGA KONTAKTMETOD].
+Klagomål kommer att granskas och utredas snabbt och rättvist.
+
+Alla gemenskapsledare är skyldiga att respektera rapportörens integritet och säkerhet oavsett incident.
+
+## Riktlinjer för tillämpning
+
+Gemenskapsledare kommer att följa dessa riktlinjer för att avgöra konsekvenserna för handlingar som de anser strider mot denna uppförandekod:
+
+### 1. Rättelse
+
+**Påverkan på gemenskapen**: Användande av olämpligt språk eller annat beteende som anses vara oprofessionellt eller opassande i gemenskapen.
+
+**Konsekvens**: En privat, skriftlig varning från gemenskapsansvariga, en tydlig förklaring av överträdelsens art och till varför beteendet var olämpligt. En offentlig ursäkt kan begäras.
+
+### 2. Varning
+
+**Påverkan på gemenskapen**: En överträdelse genom en enskild incident eller serie av
+åtgärder.
+
+**Konsekvens**: En varning med konsekvenser om beteendet fortsätter. Ingen
+interaktion med de inblandade personerna, inklusive oönskad interaktion med
+de som upprätthåller uppförandekoden, under en viss tidsperiod. 
+Det inkluderar att undvika interaktioner i gemenskapsutrymmen såväl som externa kanaler som sociala medier. Överträdelse mot dessa villkor kan leda till en tillfällig eller permanent utslutning ur gemenskapen.
+
+### 3. Tillfälligt förbud
+
+**Påverkan på gemenskapen**: En allvarlig överträdelse mot gemenskapsstandarder, inklusive ett kontinuerligt olämpligt beteende.
+
+**Konsekvens**: Ett tillfälligt förbud från någon form av interaktion eller offentlig kommunikation med gemenskapen under en viss tidsperiod.
+Ingen offentlig eller privat interaktion med de inblandade personerna, inklusive oönskad interaktion
+med dem som upprätthåller uppförandekoden, tillåts under denna period.
+Överträdelse mot dessa villkor kan leda till ett permanent förbud.
+
+### 4. Permanent förbud
+
+**Påverkan på gemenskapen**: Visar ett mönster av överträdelser av gemenskapens
+riktlinjer, inklusive kontinuerligt olämpligt beteende, trakasserier av en
+individ, eller aggression eller nedvärderande av grupper av individer.
+
+**Konsekvens**: Ett permanent förbud för alla former av offentlig interaktion inom
+gemenskapen.
+
+## Erkännanden
+
+Denna uppförandekod är en översättning av [Contributor Covenant][hemsida],
+version 2.1, tillgänglig på
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Uppförandekoden inspirerades av
+[Mozillas uppförandekod][Mozilla CoC].
+
+För svar på vanliga frågor kring denna uppförandekod, se "Vanliga frågor (F.A.Q)", 
+[https://www.contributor-covenant.org/faq][FAQ]. 
+Översättningar finns tillgängliga på
+[https://www.contributor-covenant.org/translations][translations].
+
+[hemsida]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations


### PR DESCRIPTION
The latest Swedish translation was 1.4. This is an 2.1 retranslation, trying to use terms common in the Swedish Open Source world. with terms like erkännande=attribution, uppförandekod=code of conduct, gemenskap=community etc.

It it most likely not perfect, but ok  ,I threw it out for review on LinkedIn also - https://www.linkedin.com/posts/josefandersson_contributor-covenant-activity-6995726643499544576-doem?utm_source=share&utm_medium=member_desktop -, where there are quite a few people in the Swedish Open Source Community. So I'll hopefully I'll get some further feedback if there is anything important to fix. And.. I also intend to update the Swedish translation in the future, if I get suggestions or discover something odd.

Signed-off-by: Josef Andersson <josef.andersson@gmail.com>
