### PR TITLE
add bbc to adopters

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -27,6 +27,7 @@ Babel, https://github.com/babel/babel
 Backlight deb packages, https://github.com/gorlapraveen/blacklight-deb-packages
 Baleen CLI, https://github.com/baleen/cli
 Baleen Migrations, https://github.com/baleen/migrations
+BBC, https://www.bbc.co.uk/opensource
 BcnEng, https://bcneng.org
 Beagle Framework,https://github.com/ZupIT/beagle
 Bearsampp, https://bearsampp.com/code-of-conduct

--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -27,7 +27,6 @@ Babel, https://github.com/babel/babel
 Backlight deb packages, https://github.com/gorlapraveen/blacklight-deb-packages
 Baleen CLI, https://github.com/baleen/cli
 Baleen Migrations, https://github.com/baleen/migrations
-BBC, https://www.bbc.co.uk/opensource
 BcnEng, https://bcneng.org
 Beagle Framework,https://github.com/ZupIT/beagle
 Bearsampp, https://bearsampp.com/code-of-conduct
@@ -363,6 +362,7 @@ Teem, https://github.com/P2Pvalue/teem/
 TensorFlow, https://github.com/tensorflow/tensorflow
 Termidinator, https://github.com/Yaacoub/Termidinator
 The Anadromi Project, https://github.com/anadromi/the-anadromi-project
+The British Broadcasting Corporation (BBC), https://www.bbc.co.uk/opensource
 The PHP League OAuth 2.0 Server, https://github.com/thephpleague/oauth2-server
 ThePew Inc., https://github.com/the-pew-inc/the-pew
 Tide, https://github.com/wptide/wptide


### PR DESCRIPTION
# Contributor Covenant Adoption

## Project name
Open Source projects maintained by [The British Broadcasting Corporation (BBC)](https://www.bbc.co.uk/aboutthebbc/)

## Project repository
[Open Source Software Development at the BBC](https://www.bbc.co.uk/opensource/)

## Link to code of conduct in your project's repo or documentation
We currently have a number of Open Source projects maintained by the organisation that have adopted the Contributer Covenant. An example of which can be found in the [Simorgh](https://github.com/bbc/simorgh/blob/latest/.github/CODE_OF_CONDUCT.md) project.

Whilst not all of our projects have adopted the Contributer Covenant, we are currently working towards migrating projects over to it where appropriate. 

## Check your work!
Please double-check that you inserted the contact method for reporting incidents in the template. (Search the document for `[INSERT CONTACT METHOD]`)
- Checked ✅

*Thank you!*
- You are very welcome! Thank you @CoralineAda for maintaining this project.