### PR TITLE
Add ActivityWatch to adopters

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -407,3 +407,4 @@ ZoneMinder, https://github.com/ZoneMinder/
 AB3C, https://ab3c.org.br/
 OpenPrivacyTech, https://github.com/openprivacytech
 NicFab Privacy Community, https://community.nicfab.it
+ActivityWatch, https://github.com/ActivityWatch


### PR DESCRIPTION
# Contributor Covenant Adoption

## Project name
ActivityWatch

## Project repository
https://github.com/ActivityWatch/activitywatch

## Link to code of conduct in your project's repo or documentation
[CODE_OF_CONDUCT.md](https://github.com/ActivityWatch/activitywatch/blob/master/CODE_OF_CONDUCT.md), also mentioned in `CONTRIBUTING.md`.

## Check your work!
 - [x] Please double-check that you inserted the contact method for reporting incidents in the template. (Search the document for `[INSERT CONTACT METHOD]`)