### PR TITLE
update BBC listing

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -27,7 +27,7 @@ Babel, https://github.com/babel/babel
 Backlight deb packages, https://github.com/gorlapraveen/blacklight-deb-packages
 Baleen CLI, https://github.com/baleen/cli
 Baleen Migrations, https://github.com/baleen/migrations
-BBC (The British Broadcasting Corporation), https://www.bbc.co.uk/opensource
+BBC, https://www.bbc.co.uk/opensource
 BcnEng, https://bcneng.org
 Beagle Framework,https://github.com/ZupIT/beagle
 Bearsampp, https://bearsampp.com/code-of-conduct

--- a/static/featured-adopters.csv
+++ b/static/featured-adopters.csv
@@ -3,7 +3,7 @@ Atom, https://github.com/atom/atom
 AngularJS, https://github.com/angular/code-of-conduct
 Babel, https://github.com/babel/babel
 Bootstrap, https://github.com/twbs/bootstrap
-BBC (The British Broadcasting Corporation), https://www.bbc.co.uk/opensource
+BBC, https://www.bbc.co.uk/opensource
 Bundler, https://github.com/rubygems/bundler
 chef-rvm, https://github.com/sous-chefs/rvm
 Cloud Native Compute Foundation, https://www.cncf.io/


### PR DESCRIPTION
This is a follow up PR to the original https://github.com/EthicalSource/contributor_covenant/pull/1225

It updates the name used for the BBC listing to be in line with our brand guidelines. The name is now just the shorter form `BBC` as opposed to the full `The British Broadcasting Corporation`.

Thanks!