### PR TITLE
Adds Devtron to adopters

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -94,6 +94,7 @@ Deckhouse, https://github.com/deckhouse/deckhouse
 Dependent, https://github.com/dependent/dependencies
 DevAndDev, https://devand.dev/
 Deviser Platform, https://github.com/deviserplatform/deviserplatform
+Devtron, https://github.com/devtron-labs/devtron
 Diaspora, https://github.com/diaspora/diaspora
 Discourse, https://github.com/discourse/discourse
 Diversity Handbook, https://github.com/DanRoeSparks/diversity-handbook


### PR DESCRIPTION
# Contributor Covenant Adoption

## Project name
Devtron

## Project repository
https://github.com/devtron-labs/devtron

## Link to code of conduct in your project's repo or documentation
[Code of conduct](https://github.com/devtron-labs/devtron/blob/main/CODE_OF_CONDUCT.md)

## Check your work!
- [x] Please double-check that you inserted the contact method for reporting incidents in the template. (Search the document for `[INSERT CONTACT METHOD]`) - 


*Thank you!*
