### PR TITLE
Correct declared aliases in translated files

### DIFF
--- a/content/version/1/4/code-of-conduct.ar.md
+++ b/content/version/1/4/code-of-conduct.ar.md
@@ -1,6 +1,6 @@
 +++
 version = "1.4"
-aliases = ["/version/1/4"]
+aliases = ["/version/1/4/ar"]
 +++
 
 # ميثاق القواعد السلوكية للمساهمين

--- a/content/version/1/4/code-of-conduct.hu.md
+++ b/content/version/1/4/code-of-conduct.hu.md
@@ -1,6 +1,6 @@
 +++
 version = "1.4"
-aliases = ["/version/1/4"]
+aliases = ["/version/1/4/hu"]
 +++
 
 # Közreműködők Magatartási Kódexe

--- a/content/version/1/4/code-of-conduct.id.md
+++ b/content/version/1/4/code-of-conduct.id.md
@@ -1,6 +1,6 @@
 +++
 version = "1.4"
-aliases = ["/version/1/4"]
+aliases = ["/version/1/4/id"]
 +++
 
 # Kode Etik Contributor Covenant

--- a/content/version/1/4/code-of-conduct.it.md
+++ b/content/version/1/4/code-of-conduct.it.md
@@ -1,6 +1,6 @@
 +++
 version = "1.4"
-aliases = ["/version/1/4"]
+aliases = ["/version/1/4/it"]
 +++
 
 # Codice di Comportamento del Collaboratore

--- a/content/version/2/0/code_of_conduct.id.md
+++ b/content/version/2/0/code_of_conduct.id.md
@@ -1,6 +1,6 @@
 +++
 version = "2.0"
-aliases = ["/version/2/0"]
+aliases = ["/version/2/0/id"]
 +++
 
 # Kode Etik Contributor Covenant

--- a/content/version/2/0/code_of_conduct.it.md
+++ b/content/version/2/0/code_of_conduct.it.md
@@ -1,6 +1,6 @@
 +++
 version = "2.0"
-aliases = ["/version/2/0"]
+aliases = ["/version/2/0/it"]
 +++
 
 # Codice di Comportamento del Collaboratore

--- a/content/version/2/0/code_of_conduct.ja.md
+++ b/content/version/2/0/code_of_conduct.ja.md
@@ -1,6 +1,6 @@
 +++
 version = "2.0"
-aliases = ["/version/2/0"]
+aliases = ["/version/2/0/ja"]
 +++
 
 # コントリビューター行動規範

--- a/content/version/2/0/code_of_conduct.nl.md
+++ b/content/version/2/0/code_of_conduct.nl.md
@@ -1,6 +1,6 @@
 +++
 version = "2.0"
-aliases = ["/version/2/0"]
+aliases = ["/version/2/0/nl"]
 +++
 
 # Contributor Covenant Gedragscode (Code of Conduct)

--- a/content/version/2/0/code_of_conduct.pt-br.md
+++ b/content/version/2/0/code_of_conduct.pt-br.md
@@ -1,6 +1,6 @@
 +++
 version = "2.0"
-aliases = ["/version/2/0"]
+aliases = ["/version/2/0/pt-br"]
 +++
 
 # Código de Conduta de Colaboração

--- a/content/version/2/0/code_of_conduct.ru.md
+++ b/content/version/2/0/code_of_conduct.ru.md
@@ -1,6 +1,6 @@
 +++
 version = "2.0"
-aliases = ["/version/2/0"]
+aliases = ["/version/2/0/ru"]
 +++
 
 # Кодекс Поведения участника

--- a/content/version/2/0/code_of_conduct.tr.md
+++ b/content/version/2/0/code_of_conduct.tr.md
@@ -1,6 +1,6 @@
 +++
 version = "2.0"
-aliases = ["/version/2/0"]
+aliases = ["/version/2/0/tr"]
 +++
 
 # Katkıcı Ahdi Topluluk Sözleşmesi

--- a/content/version/2/1/code_of_conduct.it.md
+++ b/content/version/2/1/code_of_conduct.it.md
@@ -1,6 +1,6 @@
 +++
 version = "2.1"
-aliases = ["/version/2/1"]
+aliases = ["/version/2/1/it"]
 +++
 
 # Codice di Comportamento del Collaboratore 


### PR DESCRIPTION
Hi there!

I noticed that https://contributor-covenant.org/version/1/4 was redirecting to `/it/` -- it looks like a few translations are all declaring competing ownership for some of the base version aliases.

This fixes all the current instances; I have no idea whether it would be practical to lint against this reoccurring when future translations are added.