### PR TITLE
Some small fixes to the Italian translation v2.1

### DIFF
--- a/content/version/2/1/code_of_conduct.it.md
+++ b/content/version/2/1/code_of_conduct.it.md
@@ -7,93 +7,96 @@ aliases = ["/version/2/1"]
 
 ## Il Nostro Impegno
 
-Nell'interesse della promozione di un ambiente aperto e accogliente,
-noicontributori e manutentori ci impegnamo a rendere la partecipazione alla
-nostracomunità un'esperienza libera da molestie per tutti, indipendentemente
-dall'età,corporatura, disabilità visibile o meno, etnia,caratteristiche
-sessuali, identità ed espressione di genere, livello diesperienza, istruzione,
-stato socio-economico, nazionalità, aspetto, razza, casta, colore della
-pellereligione o identità e orientamento sessuale.
+Nell'interesse della promozione di un ambiente aperto e accogliente, noi
+contributori e manutentori ci impegnamo a rendere la partecipazione alla nostra
+comunità un'esperienza libera da molestie per tutti, indipendentemente dall'età,
+corporatura, disabilità visibile o meno, etnia, caratteristiche sessuali,
+identità ed espressione di genere, livello di esperienza, istruzione, stato
+socio-economico, nazionalità, aspetto, razza, casta, colore della pelle,
+religione o identità e orientamento sessuale.
 
 Noi ci impegniamo ad agire ed interagire per costruire una comunità aperta,
 accogliente, diversificata, inclusiva e sana.
 
 ## I nostri Standard
 
-Esempi di comportamenti che contribuiscono alla creazione di un
-ambientepositivo per la nostra comunità:
+Esempi di comportamenti che contribuiscono alla creazione di un ambiente
+positivo per la nostra comunità:
 
-* Dimostrare empatia e gentilezza verso le altre persone* Rispettare le
-opinioni, i punti di vista ed esperienze differenti* Fornire, con garbo,
-critiche costruttive* Prendersi la responsabilità di quanto sostenuto e
-scusarsi verso le persone  colpite dai nostri sbagli, imparando da queste
-esperienze* Concentrarsi non su ciò che è meglio per noi come individui, ma su
-ciò  che è meglio per la comunità
+* Dimostrare empatia e gentilezza verso le altre persone
+* Rispettare le opinioni, i punti di vista ed esperienze differenti
+* Fornire, con garbo, critiche costruttive
+* Prendersi la responsabilità di quanto sostenuto e scusarsi verso le persone
+  colpite dai nostri sbagli, imparando da queste esperienze
+* Concentrarsi non su ciò che è meglio per noi come individui, ma su ciò che è
+  meglio per la comunità
 
 Esempi di comportamento inaccettabile:
 
-* L'uso di linguaggio o immagini sessualizzate e l'attenzione sessuale o
-avance indesiderate* Comportamenti da troll, commenti offensivi e attacchi
-personali o politici* Molestie in pubblico o in privato* Pubblicazione di
-informazioni private altrui, ad esempio un indirizzo postale o  elettronico,
-senza autorizzazione esplicita* Altri comportamenti che potrebbero
-ragionevolmente essere considerati  inappropriati in un contesto professionale
+* L'uso di linguaggio o immagini sessualizzate e l'attenzione sessuale o avance
+  indesiderate
+* Comportamenti da troll, commenti offensivi e attacchi personali o politici
+* Molestie in pubblico o in privato
+* Pubblicazione di informazioni private altrui, ad esempio un indirizzo postale
+  o elettronico, senza autorizzazione esplicita
+* Altri comportamenti che potrebbero ragionevolmente essere considerati
+  inappropriati in un contesto professionale
 
 ## Adempimento e Responsabilità
 
-Le persone alla guida della comunità sono responsabili del chiarimento
-edell'applicazione degli standard di comportamento accettabili e sono tenuti
-aintraprendere azioni correttive appropriate ed eque in risposta a qualsiasi
-caso di comportamento inaccettabile, minaccioso, offensivo o dannoso.
+Le persone alla guida della comunità sono responsabili del chiarimento e
+dell'applicazione degli standard di comportamento accettabili e sono tenuti a
+intraprendere azioni correttive appropriate ed eque in risposta a qualsiasi caso
+di comportamento inaccettabile, minaccioso, offensivo o dannoso.
 
-Le persone alla guida della comunità hanno il diritto e la responsabilità
-dirimuovere, modificare o rifiutare commenti, commit, codice, modifiche dei
-wiki,issue e altri contributi non allineati a questo Codice di Comportamento,
-comunicandole ragioni dell'intervento di moderazione quando opportuno.
+Le persone alla guida della comunità hanno il diritto e la responsabilità di
+rimuovere, modificare o rifiutare commenti, commit, codice, modifiche dei wiki,
+issue e altri contributi non allineati a questo Codice di Comportamento,
+comunicando le ragioni dell'intervento di moderazione quando opportuno.
 
 ## Scopo
 
 Questo Codice di Comportamento si applica sia all'interno degli spazi della
-comunitàche negli spazi pubblici quando un individuo rappresenta la sua
-comunità.Esempi di rappresentanza della nostra comunità includono l'uso di un
-indirizzo e-mailufficiale del progetto, la pubblicazione tramite un account
-ufficiale attraversosocial media o la funzione di rappresentante designato ad
+comunità che negli spazi pubblici quando un individuo rappresenta la sua
+comunità. Esempi di rappresentanza della nostra comunità includono l'uso di un
+indirizzo e-mail ufficiale del progetto, la pubblicazione tramite un account
+ufficiale attraverso social media o la funzione di rappresentante designato ad
 un evento online o offline.
 
 ## Applicazione
 
-I casi di comportamento abusivo, molesto o altrimenti inaccettabile
-possonoessere presentate contattando i responsabili dell'applicazione di questo
-Codice di Condotta della comunità all'indirizzo [INSERISCI INDIRIZZO EMAIL]
-.Tutti i reclami saranno prontamente esaminati ed indagati.
+I casi di comportamento abusivo, molesto o altrimenti inaccettabile possono
+essere presentate contattando i responsabili dell'applicazione di questo Codice
+di Condotta della comunità all'indirizzo [INSERISCI INDIRIZZO EMAIL]. Tutti i
+reclami saranno prontamente esaminati ed indagati.
 
 Tutte le guide della comunità sono obbligate a mantenere la riservatezza della
 persona che ha riportato il caso.
 
 ## Linee guida all'applicazione
 
-Le guide della comunità seguiranno queste linee guida per determinare le
-azionicorrettive contro azioni che ritengono violare questo Codice di Condotta:
+Le guide della comunità seguiranno queste linee guida per determinare le azioni
+correttive contro azioni che ritengono violare questo Codice di Condotta:
 
 ### 1. Correzione
 
 **Impatto nella comunità**: Uso di linguaggio inappropriato o altri
-comportamentigiudicati non professionali o ostili nella community.
+comportamenti giudicati non professionali o ostili nella community.
 
 **Conseguenze**: Un avviso scritto in forma privata dalle guide della comunità,
 spiegando la natura della violazione e perché il comportamento era
-inappopriato.Pubbliche scuse potrebbero essere richieste.
+inappopriato. Pubbliche scuse potrebbero essere richieste.
 
 ### 2. Avviso
 
-**Impatto nella comunità**: Una violazione dopo un episodio avvenuto o una
-serie di azioni negative.
+**Impatto nella comunità**: Una violazione dopo un episodio avvenuto o una serie
+di azioni negative.
 
 **Conseguenze**: Un avviso per il comportamento perpetrato. Nessuna
-comunicazione perun periodo di tempo specificato con le persone coinvolte,
-incluse quelle cheapplicano il Codice di Condotta. Questo comprende
-l'inibizione alla partecipazionenegli spazi della comunità come canali esterni
-quali i social media.Violare questi termini può portare ad una espulsione
+comunicazione per un periodo di tempo specificato con le persone coinvolte,
+incluse quelle che applicano il Codice di Condotta. Questo comprende
+l'inibizione alla partecipazione negli spazi della comunità come canali esterni
+quali i social media. Violare questi termini può portare ad una espulsione
 temporanea o permanente.
 
 ### 3. Espulsione temporanea
@@ -101,17 +104,17 @@ temporanea o permanente.
 **Impatto nella comunità**: Una grave violazione agli standard della comunità,
 incluso mantenere un comportamento inappropriato.
 
-**Conseguenze**: Espulsione temporanea per un periodo di tempo specificato
-aqualsiasi sorta di interazione o comunicazione con la comunità. Durante
-questoperiodo non è permesso nessun dialogo pubblico o privato con le persone
-coinvolte,comprese coloro che applicano il Codice di Condotta.Violare questi
+**Conseguenze**: Espulsione temporanea per un periodo di tempo specificato a
+qualsiasi sorta di interazione o comunicazione con la comunità. Durante questo
+periodo non è permesso nessun dialogo pubblico o privato con le persone
+coinvolte, comprese coloro che applicano il Codice di Condotta. Violare questi
 termini può portare ad una espulsione permanente.
 
 ### 4. Espulsione permanente
 
-**Impatto nella comunità**: Dimostrare sistematicamente di violare gli
-standarddella comunità, inclusa la ripetezione di comportamenti inappropriati,
-molestieo aggressioni individuali o denigrazione di gruppi di individui.
+**Impatto nella comunità**: Dimostrare sistematicamente di violare gli standard
+della comunità, inclusa la ripetezione di comportamenti inappropriati, molestie
+o aggressioni individuali o denigrazione di gruppi di individui.
 
 **Conseguenze**: Espulsione permanente da ogni interazione pubblica della
 comunità.
@@ -119,8 +122,8 @@ comunità.
 ## Attribuzione
 
 Questo Codice di Comportamento è adattato dal [Contributor Covenant][homepage],
-versione 2.0, disponibile all'indirizzo https://www.contributor-
-covenant.org/version/2/0/code-of-conduct.html
+versione 2.0, disponibile all'indirizzo
+https://www.contributor-covenant.org/version/2/0/code-of-conduct.html
 
 Le linee guida all'applicazione sono state ispirate dal [codice di condotta di
 Mozilla](https://github.com/mozilla/diversity).
@@ -129,6 +132,6 @@ Mozilla](https://github.com/mozilla/diversity).
 [homepage]: https://www.contributor-covenant.org
 
 Per riposte a domande comuni riguardo questo codice di condotta,controlla le
-domande frequenti al link https://www.contributor-covenant.org/faq.Le
-traduzioni sono disponibili al link https://www.contributor-
-covenant.org/translations.
+domande frequenti al link https://www.contributor-covenant.org/faq . Le
+traduzioni sono disponibili al link
+https://www.contributor-covenant.org/translations .

--- a/content/version/2/1/code_of_conduct.it.md
+++ b/content/version/2/1/code_of_conduct.it.md
@@ -122,8 +122,8 @@ comunità.
 ## Attribuzione
 
 Questo Codice di Comportamento è adattato dal [Contributor Covenant][homepage],
-versione 2.0, disponibile all'indirizzo
-https://www.contributor-covenant.org/version/2/0/code-of-conduct.html
+versione 2.1, disponibile all'indirizzo
+https://www.contributor-covenant.org/version/2/1/code_of_conduct
 
 Le linee guida all'applicazione sono state ispirate dal [codice di condotta di
 Mozilla](https://github.com/mozilla/diversity).

--- a/content/version/2/1/code_of_conduct.it.md
+++ b/content/version/2/1/code_of_conduct.it.md
@@ -85,7 +85,7 @@ comportamenti giudicati non professionali o ostili nella community.
 
 **Conseguenze**: Un avviso scritto in forma privata dalle guide della comunità,
 spiegando la natura della violazione e perché il comportamento era
-inappopriato. Pubbliche scuse potrebbero essere richieste.
+inappropriato. Pubbliche scuse potrebbero essere richieste.
 
 ### 2. Avviso
 
@@ -113,7 +113,7 @@ termini può portare ad una espulsione permanente.
 ### 4. Espulsione permanente
 
 **Impatto nella comunità**: Dimostrare sistematicamente di violare gli standard
-della comunità, inclusa la ripetezione di comportamenti inappropriati, molestie
+della comunità, inclusa la ripetizione di comportamenti inappropriati, molestie
 o aggressioni individuali o denigrazione di gruppi di individui.
 
 **Conseguenze**: Espulsione permanente da ogni interazione pubblica della

--- a/content/version/2/1/code_of_conduct.it.md
+++ b/content/version/2/1/code_of_conduct.it.md
@@ -123,15 +123,18 @@ comunità.
 
 Questo Codice di Comportamento è adattato dal [Contributor Covenant][homepage],
 versione 2.1, disponibile all'indirizzo
-https://www.contributor-covenant.org/version/2/1/code_of_conduct
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct][v2.1].
 
 Le linee guida all'applicazione sono state ispirate dal [codice di condotta di
-Mozilla](https://github.com/mozilla/diversity).
-
-
-[homepage]: https://www.contributor-covenant.org
+Mozilla][Mozilla CoC].
 
 Per riposte a domande comuni riguardo questo codice di condotta,controlla le
-domande frequenti al link https://www.contributor-covenant.org/faq . Le
+domande frequenti al link [https://www.contributor-covenant.org/faq][FAQ]. Le
 traduzioni sono disponibili al link
-https://www.contributor-covenant.org/translations .
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/content/version/2/1/code_of_conduct.it.md
+++ b/content/version/2/1/code_of_conduct.it.md
@@ -3,132 +3,132 @@ version = "2.1"
 aliases = ["/version/2/1"]
 +++
 
-# Codice di Comportamento del Collaboratore 
+# Codice di Comportamento del Collaboratore
 
-## Il Nostro Impegno 
+## Il Nostro Impegno
 
-Nell'interesse della promozione di un ambiente aperto e accogliente, 
-noicontributori e manutentori ci impegnamo a rendere la partecipazione alla 
-nostracomunità un'esperienza libera da molestie per tutti, indipendentemente 
-dall'età,corporatura, disabilità visibile o meno, etnia,caratteristiche 
-sessuali, identità ed espressione di genere, livello diesperienza, istruzione, 
-stato socio-economico, nazionalità, aspetto, razza, casta, colore della 
-pellereligione o identità e orientamento sessuale. 
+Nell'interesse della promozione di un ambiente aperto e accogliente,
+noicontributori e manutentori ci impegnamo a rendere la partecipazione alla
+nostracomunità un'esperienza libera da molestie per tutti, indipendentemente
+dall'età,corporatura, disabilità visibile o meno, etnia,caratteristiche
+sessuali, identità ed espressione di genere, livello diesperienza, istruzione,
+stato socio-economico, nazionalità, aspetto, razza, casta, colore della
+pellereligione o identità e orientamento sessuale.
 
 Noi ci impegniamo ad agire ed interagire per costruire una comunità aperta,
-accogliente, diversificata, inclusiva e sana. 
+accogliente, diversificata, inclusiva e sana.
 
-## I nostri Standard 
+## I nostri Standard
 
-Esempi di comportamenti che contribuiscono alla creazione di un 
-ambientepositivo per la nostra comunità: 
+Esempi di comportamenti che contribuiscono alla creazione di un
+ambientepositivo per la nostra comunità:
 
-* Dimostrare empatia e gentilezza verso le altre persone* Rispettare le 
-opinioni, i punti di vista ed esperienze differenti* Fornire, con garbo, 
-critiche costruttive* Prendersi la responsabilità di quanto sostenuto e 
-scusarsi verso le persone  colpite dai nostri sbagli, imparando da queste 
-esperienze* Concentrarsi non su ciò che è meglio per noi come individui, ma su 
-ciò  che è meglio per la comunità 
+* Dimostrare empatia e gentilezza verso le altre persone* Rispettare le
+opinioni, i punti di vista ed esperienze differenti* Fornire, con garbo,
+critiche costruttive* Prendersi la responsabilità di quanto sostenuto e
+scusarsi verso le persone  colpite dai nostri sbagli, imparando da queste
+esperienze* Concentrarsi non su ciò che è meglio per noi come individui, ma su
+ciò  che è meglio per la comunità
 
-Esempi di comportamento inaccettabile: 
+Esempi di comportamento inaccettabile:
 
-* L'uso di linguaggio o immagini sessualizzate e l'attenzione sessuale o  
-avance indesiderate* Comportamenti da troll, commenti offensivi e attacchi 
-personali o politici* Molestie in pubblico o in privato* Pubblicazione di 
-informazioni private altrui, ad esempio un indirizzo postale o  elettronico, 
-senza autorizzazione esplicita* Altri comportamenti che potrebbero 
-ragionevolmente essere considerati  inappropriati in un contesto professionale 
+* L'uso di linguaggio o immagini sessualizzate e l'attenzione sessuale o
+avance indesiderate* Comportamenti da troll, commenti offensivi e attacchi
+personali o politici* Molestie in pubblico o in privato* Pubblicazione di
+informazioni private altrui, ad esempio un indirizzo postale o  elettronico,
+senza autorizzazione esplicita* Altri comportamenti che potrebbero
+ragionevolmente essere considerati  inappropriati in un contesto professionale
 
-## Adempimento e Responsabilità 
+## Adempimento e Responsabilità
 
-Le persone alla guida della comunità sono responsabili del chiarimento 
-edell'applicazione degli standard di comportamento accettabili e sono tenuti 
-aintraprendere azioni correttive appropriate ed eque in risposta a qualsiasi 
-caso di comportamento inaccettabile, minaccioso, offensivo o dannoso. 
+Le persone alla guida della comunità sono responsabili del chiarimento
+edell'applicazione degli standard di comportamento accettabili e sono tenuti
+aintraprendere azioni correttive appropriate ed eque in risposta a qualsiasi
+caso di comportamento inaccettabile, minaccioso, offensivo o dannoso.
 
-Le persone alla guida della comunità hanno il diritto e la responsabilità 
-dirimuovere, modificare o rifiutare commenti, commit, codice, modifiche dei 
-wiki,issue e altri contributi non allineati a questo Codice di Comportamento, 
-comunicandole ragioni dell'intervento di moderazione quando opportuno. 
+Le persone alla guida della comunità hanno il diritto e la responsabilità
+dirimuovere, modificare o rifiutare commenti, commit, codice, modifiche dei
+wiki,issue e altri contributi non allineati a questo Codice di Comportamento,
+comunicandole ragioni dell'intervento di moderazione quando opportuno.
 
-## Scopo 
+## Scopo
 
-Questo Codice di Comportamento si applica sia all'interno degli spazi della 
-comunitàche negli spazi pubblici quando un individuo rappresenta la sua 
-comunità.Esempi di rappresentanza della nostra comunità includono l'uso di un 
-indirizzo e-mailufficiale del progetto, la pubblicazione tramite un account 
-ufficiale attraversosocial media o la funzione di rappresentante designato ad 
-un evento online o offline. 
+Questo Codice di Comportamento si applica sia all'interno degli spazi della
+comunitàche negli spazi pubblici quando un individuo rappresenta la sua
+comunità.Esempi di rappresentanza della nostra comunità includono l'uso di un
+indirizzo e-mailufficiale del progetto, la pubblicazione tramite un account
+ufficiale attraversosocial media o la funzione di rappresentante designato ad
+un evento online o offline.
 
-## Applicazione 
+## Applicazione
 
-I casi di comportamento abusivo, molesto o altrimenti inaccettabile 
-possonoessere presentate contattando i responsabili dell'applicazione di questo 
+I casi di comportamento abusivo, molesto o altrimenti inaccettabile
+possonoessere presentate contattando i responsabili dell'applicazione di questo
 Codice di Condotta della comunità all'indirizzo [INSERISCI INDIRIZZO EMAIL]
-.Tutti i reclami saranno prontamente esaminati ed indagati. 
+.Tutti i reclami saranno prontamente esaminati ed indagati.
 
-Tutte le guide della comunità sono obbligate a mantenere la riservatezza della 
-persona che ha riportato il caso. 
+Tutte le guide della comunità sono obbligate a mantenere la riservatezza della
+persona che ha riportato il caso.
 
-## Linee guida all'applicazione 
+## Linee guida all'applicazione
 
-Le guide della comunità seguiranno queste linee guida per determinare le 
-azionicorrettive contro azioni che ritengono violare questo Codice di Condotta: 
+Le guide della comunità seguiranno queste linee guida per determinare le
+azionicorrettive contro azioni che ritengono violare questo Codice di Condotta:
 
-### 1. Correzione 
+### 1. Correzione
 
-**Impatto nella comunità**: Uso di linguaggio inappropriato o altri 
-comportamentigiudicati non professionali o ostili nella community. 
+**Impatto nella comunità**: Uso di linguaggio inappropriato o altri
+comportamentigiudicati non professionali o ostili nella community.
 
 **Conseguenze**: Un avviso scritto in forma privata dalle guide della comunità,
-spiegando la natura della violazione e perché il comportamento era 
-inappopriato.Pubbliche scuse potrebbero essere richieste. 
+spiegando la natura della violazione e perché il comportamento era
+inappopriato.Pubbliche scuse potrebbero essere richieste.
 
-### 2. Avviso 
+### 2. Avviso
 
-**Impatto nella comunità**: Una violazione dopo un episodio avvenuto o una 
-serie di azioni negative. 
+**Impatto nella comunità**: Una violazione dopo un episodio avvenuto o una
+serie di azioni negative.
 
-**Conseguenze**: Un avviso per il comportamento perpetrato. Nessuna 
-comunicazione perun periodo di tempo specificato con le persone coinvolte, 
-incluse quelle cheapplicano il Codice di Condotta. Questo comprende 
-l'inibizione alla partecipazionenegli spazi della comunità come canali esterni 
-quali i social media.Violare questi termini può portare ad una espulsione 
-temporanea o permanente. 
+**Conseguenze**: Un avviso per il comportamento perpetrato. Nessuna
+comunicazione perun periodo di tempo specificato con le persone coinvolte,
+incluse quelle cheapplicano il Codice di Condotta. Questo comprende
+l'inibizione alla partecipazionenegli spazi della comunità come canali esterni
+quali i social media.Violare questi termini può portare ad una espulsione
+temporanea o permanente.
 
-### 3. Espulsione temporanea 
+### 3. Espulsione temporanea
 
-**Impatto nella comunità**: Una grave violazione agli standard della comunità, 
-incluso mantenere un comportamento inappropriato. 
+**Impatto nella comunità**: Una grave violazione agli standard della comunità,
+incluso mantenere un comportamento inappropriato.
 
-**Conseguenze**: Espulsione temporanea per un periodo di tempo specificato 
-aqualsiasi sorta di interazione o comunicazione con la comunità. Durante 
-questoperiodo non è permesso nessun dialogo pubblico o privato con le persone 
-coinvolte,comprese coloro che applicano il Codice di Condotta.Violare questi 
-termini può portare ad una espulsione permanente. 
+**Conseguenze**: Espulsione temporanea per un periodo di tempo specificato
+aqualsiasi sorta di interazione o comunicazione con la comunità. Durante
+questoperiodo non è permesso nessun dialogo pubblico o privato con le persone
+coinvolte,comprese coloro che applicano il Codice di Condotta.Violare questi
+termini può portare ad una espulsione permanente.
 
-### 4. Espulsione permanente 
+### 4. Espulsione permanente
 
-**Impatto nella comunità**: Dimostrare sistematicamente di violare gli 
-standarddella comunità, inclusa la ripetezione di comportamenti inappropriati, 
-molestieo aggressioni individuali o denigrazione di gruppi di individui. 
+**Impatto nella comunità**: Dimostrare sistematicamente di violare gli
+standarddella comunità, inclusa la ripetezione di comportamenti inappropriati,
+molestieo aggressioni individuali o denigrazione di gruppi di individui.
 
-**Conseguenze**: Espulsione permanente da ogni interazione pubblica della 
-comunità. 
+**Conseguenze**: Espulsione permanente da ogni interazione pubblica della
+comunità.
 
-## Attribuzione 
+## Attribuzione
 
 Questo Codice di Comportamento è adattato dal [Contributor Covenant][homepage],
 versione 2.0, disponibile all'indirizzo https://www.contributor-
-covenant.org/version/2/0/code-of-conduct.html 
+covenant.org/version/2/0/code-of-conduct.html
 
-Le linee guida all'applicazione sono state ispirate dal [codice di condotta di 
-Mozilla](https://github.com/mozilla/diversity). 
+Le linee guida all'applicazione sono state ispirate dal [codice di condotta di
+Mozilla](https://github.com/mozilla/diversity).
 
 
-[homepage]: https://www.contributor-covenant.org 
+[homepage]: https://www.contributor-covenant.org
 
-Per riposte a domande comuni riguardo questo codice di condotta,controlla le 
-domande frequenti al link https://www.contributor-covenant.org/faq.Le 
+Per riposte a domande comuni riguardo questo codice di condotta,controlla le
+domande frequenti al link https://www.contributor-covenant.org/faq.Le
 traduzioni sono disponibili al link https://www.contributor-
-covenant.org/translations. 
+covenant.org/translations.


### PR DESCRIPTION
Hi. I've noticed that there are some small errors in the current version (2.1) of the Italian translation.

I've tried to fix them:
- Some words were joined
- The lists were broken (`*`s were in a single paragraph)
- There were two typos
- And I've updated the links in the last section as the English version (reference-style)

The translation itself is OK, it could maybe need another review, but I'm not a good translator.

Thanks for the project, and thanks to the Italian contributors.
g.
