### PR TITLE
Add spdx headers to CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,5 @@
 <!--
+SPDX-FileCopyrightText: 2014 Organization for Ethical Source
 SPDX-FileContributor: Alva <alva@alva.email>
 SPDX-FileContributor: Bantik <corey@idolhands.com>
 SPDX-FileContributor: CoralineAda <coraline@idolhands.com>

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,22 @@
+<!--
+SPDX-FileContributor: Alva <alva@alva.email>
+SPDX-FileContributor: Bantik <corey@idolhands.com>
+SPDX-FileContributor: CoralineAda <coraline@idolhands.com>
+SPDX-FileContributor: Dan Gillean <fiver-watson@users.noreply.github.com>
+SPDX-FileContributor: Drew Gates <aranaur@users.noreply.github.com>
+SPDX-FileContributor: Frederik Dudzik <4004blog@gmail.com>
+SPDX-FileContributor: Ilya Vassilevsky <vassilevsky@gmail.com>
+SPDX-FileContributor: Juanito Fatas <katehuang0320@gmail.com>
+SPDX-FileContributor: Kerri Miller <kerrizor@kerrizor.com>
+SPDX-FileContributor: Kurtis Rainbolt-Greene <me@kurtisrainboltgreene.name>
+SPDX-FileContributor: Oliver Galvin <odg@riseup.net>
+SPDX-FileContributor: Strand McCutchen <smccutchen@instructure.com>
+SPDX-FileContributor: Strand McCutchen <strand@bettermistak.es>
+SPDX-FileContributor: Vítor Galvão <info@vitorgalvao.com>
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge


### PR DESCRIPTION
I wanted to place the Code of Conduct into a project which strictly follows REUSE guidelines.

I produced this list of contributors to the code of conduct from the list of git authors. For each distinct git author e-mail address, I found the earliest year of contribution and the most recent name associated with that address as an author.

I chose to leave the duplicated individual as their contributions appear to be affiliated with two different organizations.

I created this change by running the following script at commit 3fd3bf6d12de15edfff1b30acd4de61502020a62:
```sh

set -eo pipefail

f () {
    set -x;
    reuse annotate \
        --year "$(git log -1 --oneline --reverse --date=format:%Y --format='%ad' --author $1 -- $2)" \
        --contributor "$(git log -1 --oneline --format='%aN <%aE>' --author $1)" \
        --license CC-BY-4.0 \
        "$2";
}

g () {
    git log --format='%aE' -- "$1" | sort -u | while read author; do f "$author" "$1"; done
}

g CODE_OF_CONDUCT.md
```

*Note:* I chose to show the earliest year as the copyright year based on my understanding as a layperson: usually the earliest date is the important one. I'm happy to re-roll to show latest, or a year range, and re-roll this PR if that's preferred. My goal is simply to ensure that contributors are acknowledged as well as to make the REUSE tool happy.

Thanks for your time in considering this PR.

Closes: #990.