### PR TITLE
Ensure uniformity of the word 'email' in the English text

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -52,7 +52,7 @@ decisions when appropriate.
 
 This Code of Conduct applies within all community spaces, and also applies when
 an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail address,
+Examples of representing our community include using an official email address,
 posting via an official social media account, or acting as an appointed
 representative at an online or offline event.
 

--- a/content/version/2/0/code_of_conduct.md
+++ b/content/version/2/0/code_of_conduct.md
@@ -57,7 +57,7 @@ decisions when appropriate.
 
 This Code of Conduct applies within all community spaces, and also applies when
 an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail address,
+Examples of representing our community include using an official email address,
 posting via an official social media account, or acting as an appointed
 representative at an online or offline event.
 

--- a/content/version/2/1/code_of_conduct.md
+++ b/content/version/2/1/code_of_conduct.md
@@ -57,7 +57,7 @@ decisions when appropriate.
 
 This Code of Conduct applies within all community spaces, and also applies when
 an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail address,
+Examples of representing our community include using an official email address,
 posting via an official social media account, or acting as an appointed
 representative at an online or offline event.
 


### PR DESCRIPTION
Hey team! I spotted that both "e-mail" and "email" are used within a short span in the document. I thought it might be good to standardize it to "email," which seems to be the more commonly used form. I'm a bit unsure about the best version to update—should we tweak 2.0, focus on 2.1, or both? I'm open to your suggestions and happy to make adjustments as needed. 😊🌟

<img width="1209" alt="image" src="https://github.com/EthicalSource/contributor_covenant/assets/463528/23d7d5a6-4736-4cbe-a84c-fa80857130f1">

P.S. I tried to find past PRs that deal with text edits to get a sense of how they're usually managed, but most of what I saw were updates to the list of adopters. Is there a specific label I should be looking out for to find those kinds of changes? Thanks in advance for any guidance! 🌈🙏