### PR TITLE
Uzufly adopted ‹Contributor Covenant› for all its repositories

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -389,6 +389,7 @@ Twilio, https://github.com/twilio
 Twisted, https://github.com/twisted/twisted
 União Colegial de Minas Gerais, https://github.com/ucmg
 UXP, https://github.com/MoonchildProductions/UXP
+Uzufly,https://github.com/uzufly
 Velero, https://github.com/vmware-tanzu/velero
 Viash, https://github.com/viash-io/viash
 Video.js, https://github.com/videojs/video.js


### PR DESCRIPTION
# Contributor Covenant Adoption

## Org name

[Uzufly](https://uzufly.com) @ EPFL Le Garage, Ecublens, Switzerland

## Project repository

All our public and private repositories at https://github.com/uzufly.

## Link to code of conduct in your project's repo or documentation

Examples:

[Uzufly › Exploratory › Code of conduct](https://github.com/uzufly/exploratory?tab=coc-ov-file)
[Uzufly › Showcase IFC+Cesium › Code of conduct](https://github.com/uzufly/showcase-cesium-ifc?tab=coc-ov-file)

## Check your work!

We did check the code of conduct and do have a specific e-mail address for the contact (opensource@uzufly), being delivered to the two founders and the VP of Software Engineering.

(thanks @tobie for the hint and pointing me to the pioneering work of @CoralineAda and EthicalSource!)