### PR TITLE
Rename AngularJS to Angular

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -16,7 +16,7 @@ Amsterdam.rb, https://amsrb.org/code-of-conduct/
 Ancient Beast, https://AncientBeast.com
 Android IMSI-Catcher Detector, https://github.com/CellularPrivacy/Android-IMSI-Catcher-Detector
 angular-formly, https://github.com/formly-js/angular-formly
-AngularJS, https://github.com/angular/code-of-conduct
+Angular, https://github.com/angular/code-of-conduct
 APInf, https://github.com/apinf/platform
 AppSignal, https://docs.appsignal.com/appsignal/contributing/code-of-conduct.html
 ArchiSteamFarm, https://github.com/JustArchiNET/ArchiSteamFarm

--- a/static/featured-adopters.csv
+++ b/static/featured-adopters.csv
@@ -1,6 +1,6 @@
 Project name, Project URL
 Atom, https://github.com/atom/atom
-AngularJS, https://github.com/angular/code-of-conduct
+Angular, https://github.com/angular/code-of-conduct
 Babel, https://github.com/babel/babel
 Bootstrap, https://github.com/twbs/bootstrap
 BBC, https://www.bbc.co.uk/opensource


### PR DESCRIPTION
Given as stated in https://github.com/angular/code-of-conduct it is used for all the Angular org. Not only AngularJS ([now discontinued](https://blog.angular.io/discontinued-long-term-support-for-angularjs-cc066b82e65a)). Nit pick, I know 😜

*Thank you!*
