### PR TITLE
Adding the IBEX Imaging Community to the adopters list.

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -179,6 +179,7 @@ HTML5 Boilerplate, https://github.com/h5bp/html5-boilerplate
 HTTPicnic, https://github.com/henry-anderson/HTTPicnic
 HTTPotion, https://github.com/myfreeweb/httpotion
 Huh? Dictionary, https://github.com/Yaacoub/Huh-Dictionary
+IBEX Imaging Community,https://github.com/IBEXImagingCommunity/
 icepyx, https://github.com/icesat2py/icepyx
 if me, https://github.com/ifmeorg/ifme
 Intel OTC, https://01.org/blogs/2018/intel-covenant-code


### PR DESCRIPTION
# Contributor Covenant Adoption

## Project name
The IBEX Imaging Community Knowledge-Base.

## Project repository
https://github.com/IBEXImagingCommunity/ibex_imaging_knowledge_base

## Link to code of conduct in your project's repo or documentation
[Code of conduct](https://ibeximagingcommunity.github.io/ibex_imaging_knowledge_base/code_of_conduct.html) on Knowledge-Base website.

## Check your work!
Please double-check that you inserted the contact method for reporting incidents in the template. (Search the document for `[INSERT CONTACT METHOD]`)

Done.