### PR TITLE
Use more prevalent "socioeconomic" version instead of "socio-economic"

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -5,7 +5,7 @@
 We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
+identity and expression, level of experience, education, socioeconomic status,
 nationality, personal appearance, race, caste, color, religion, or sexual identity
 and orientation.
 

--- a/content/version/2/1/code_of_conduct.md
+++ b/content/version/2/1/code_of_conduct.md
@@ -10,7 +10,7 @@ aliases = ["/version/2/1"]
 We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
+identity and expression, level of experience, education, socioeconomic status,
 nationality, personal appearance, race, caste, color, religion, or sexual
 identity and orientation.
 


### PR DESCRIPTION
Original motivation is from constantly running into this while detecting typos with codespell.
FTR, to codespell this "typo" was added within
https://github.com/codespell-project/codespell/pull/3280 and here is "recent" discussion on likely allowing both forms: https://github.com/codespell-project/codespell/pull/3353 but giving more arguments.

It is true that "socio-economic" is also known and generally considered correct.  But if someone goes to
https://www.merriam-webster.com/dictionary/socio-economic it does list it as "socioeconomic" and examples follow the version without the dash.  So it seems to be the prevalent version, and thus why not to use it instead?

.it and .ro might (or not) want to adopt too?

    ❯ git grep socio-economic  # filtered from non translated, repeated
    content/version/1/4/code-of-conduct.ro.md:statut socio-economic, naționalitate, aspect fizic, rasă, religie, identitate sau orientare sexuală.
    content/version/2/1/code_of_conduct.it.md:socio-economico, nazionalità, aspetto, razza, casta, colore della pelle,
