### PR TITLE
Change single ABOCN projects to entire org since it is fully compliant

### DIFF
--- a/static/adopters.csv
+++ b/static/adopters.csv
@@ -2,6 +2,7 @@
 01 Edu, https://github.com/01-edu
 24 Pull Requests, https://github.com/24pullrequests/24pullrequests
 A/B Tester, https://github.com/gabrieltempass/ab-tester
+A Bunch of Computer Nerds (ABOCN), https://github.com/abocn
 AASM, https://github.com/aasm/aasm
 AB3C, https://ab3c.org.br/
 ACM-W NITK, https://github.com/acm-w-nitk/acm-w-nitk.github.io
@@ -204,7 +205,6 @@ JRuby, https://github.com/jruby/jruby/
 JSON Schema, https://github.com/json-schema-org/json-schema-spec
 json-rpc, https://github.com/pavlov99/json-rpc
 JuneteenthConf, https://juneteenthconf.com/
-Kowalski Telegram Bot, https://github.com/abocn/TelegramBot
 Keptn, https://keptn.sh/
 Kibi, https://github.com/ilai-deutel/kibi
 Kickoff, https://github.com/TryKickoff/kickoff/
@@ -366,7 +366,6 @@ Soosyze CMS, https://soosyze.com/charte-code-conduite-contributeurs
 SOSC/VTU-Lab-Material, https://github.com/so-sc/VTU-Lab-Material/
 SOULs, https://github.com/elsoul/souls
 Sovereign Cloud Stack, https://github.com/SovereignCloudStack/Docs/
-SpamWatch for Kowalski, https://github.com/abocn/TelegramBot-SpamWatch/
 SPIP, https://www.spip.net/fr_rubrique91.html
 Spree, https://github.com/spree/spree
 Spring Boot, https://github.com/spring-projects/spring-boot


### PR DESCRIPTION
# Contributor Covenant Adoption

## Project name
A Bunch of Computer Nerds

## Project repository
https://github.com/abocn

## Link to code of conduct in your project's repo or documentation
[Code of conduct](https://github.com/abocn/.github/blob/main/CODE_OF_CONDUCT.md)

## Check your work!
Please double-check that you inserted the contact method for reporting incidents in the template. (Search the document for `[INSERT CONTACT METHOD]`)

- [x] Already checked

*Thank you!*
