### PR TITLE
Improve contrast on link hover

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -6,7 +6,7 @@
 /* Variables */
 :root {
   --color-primary: hsl(288, 80%, 25%);
-  --color-primary-lighter: hsl(288, 80%, 90%);
+  --color-primary-lighter: hsl(288, 80%, 45%);
   --color-primary-lightest: hsl(288, 80%, 75%);
   --color-green: hsl(153, 90%, 30%);
   --color-orange: hsl(18, 100%, 50%);


### PR DESCRIPTION
`--color-primary-lighter` was a lighter colour than `--color-primary-lightest` so I'm guessing it was changed by mistake, and so reverting to its previous value