### PR TITLE
Remove deceptive subliminal language of the far left

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,14 +3,8 @@
 ## Our Pledge
 
 We as members, contributors, and leaders pledge to make participation in our
-community a harassment-free experience for everyone, regardless of age, body
-size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, caste, color, religion, or sexual identity
-and orientation.
-
-We pledge to act and interact in ways that contribute to an open, welcoming,
-diverse, inclusive, and healthy community.
+community a harassment-free experience for everyone and maintain a healthy
+community.
 
 ## Our Standards
 


### PR DESCRIPTION
I have provided a pull-request to remove the most blatant of the subliminal leftist messaging.  It is safe to say I expect this pull-request will not be merged.

The 'Contributor Covenant Code of Conduct' originates from an individual firmly aligned with the political far left.  The technique of listing people in distinct classes is deliberately done in order to maintain a subconscious "need" for a nanny-state (CoC) that claims to "protect" the supposed "oppressed" classes (in reality these classes are not oppressed).

Heaven forbid EVERYONE simply be asked to be well mannered, as has worked well for decades.  Without a nanny-state document no less.

Do not use the 'Contributor Covenant Code of Conduct', it is a Trojan Horse containing Communism.