### PR TITLE
Define hugo outputs for HTML only pages

### DIFF
--- a/content/adopt.html
+++ b/content/adopt.html
@@ -8,6 +8,7 @@ polyfills = [
   "https://cdn.jsdelivr.net/npm/marked/marked.min.js",
   "/scripts/builder.js"
 ]
+outputs = ["html"]
 +++
 
 <h1><a name="top">Adopt Contributor Covenant</a></h1>

--- a/content/adopters.html
+++ b/content/adopters.html
@@ -2,6 +2,7 @@
 title = "Featured Adopters"
 summary = "See just some of the communities using Contributor Covenant."
 layout = "banner-dots"
+outputs = ["html"]
 +++
 
 <h1>Featured Contributor Covenant Adopters</h1>

--- a/content/contact.html
+++ b/content/contact.html
@@ -2,6 +2,7 @@
 title = "Contact Us"
 layout = "banner-grid"
 summary = "Get in touch with the maintainers of Contributor Covenant."
+outputs = ["html"]
 +++
 
 <h1>Contact Us</h1>

--- a/content/faq.md
+++ b/content/faq.md
@@ -2,6 +2,7 @@
 title = "Frequently Asked Questions about Contributor Covenant"
 summary = "Learn the facts about Contributor Covenant."
 layout = "banner-grid"
+outputs = ["html"]
 +++
 
 # Frequently Asked Questions

--- a/content/resources.html
+++ b/content/resources.html
@@ -2,6 +2,7 @@
 title = "Resources for Moderation and Enforcement"
 summary = "Read up on best practices from around the industry."
 layout = "banner-dots"
+outputs = ["html"]
 +++
 
 <h1>Resources for Community Moderators</h1>

--- a/content/translations.html
+++ b/content/translations.html
@@ -5,6 +5,7 @@ summary = "Carefully translated by volunteer native speakers into 45+ languages 
 polyfills = [
   "/scripts/world-map.js"
 ]
+outputs = ["html"]
 +++
 
 <h1>Contributor Covenant in Your Language</h1>


### PR DESCRIPTION
## Problem

There are a few build warnings for missing asciidoc, markdown, and plaintext layouts for a few pages:

```
$ hugo build
Start building sites … 
hugo v0.148.2+extended+withdeploy linux/amd64 BuildDate=2025-07-27T12:43:24Z VendorInfo=brew

WARN  found no layout file for "asciidoc" for layout "banner-grid" for kind "page": You should create a template file which matches Hugo Layouts Lookup Rules for this combination.
WARN  found no layout file for "asciidoc" for layout "banner-dots" for kind "page": You should create a template file which matches Hugo Layouts Lookup Rules for this combination.
WARN  found no layout file for "asciidoc" for kind "page": You should create a template file which matches Hugo Layouts Lookup Rules for this combination.
WARN  found no layout file for "markdown" for layout "banner-grid" for kind "page": You should create a template file which matches Hugo Layouts Lookup Rules for this combination.
WARN  found no layout file for "markdown" for kind "page": You should create a template file which matches Hugo Layouts Lookup Rules for this combination.
WARN  found no layout file for "markdown" for layout "banner-dots" for kind "page": You should create a template file which matches Hugo Layouts Lookup Rules for this combination.
WARN  found no layout file for "plaintext" for layout "banner-dots" for kind "page": You should create a template file which matches Hugo Layouts Lookup Rules for this combination.
WARN  found no layout file for "plaintext" for kind "page": You should create a template file which matches Hugo Layouts Lookup Rules for this combination.
WARN  found no layout file for "plaintext" for layout "banner-grid" for kind "page": You should create a template file which matches Hugo Layouts Lookup Rules for this combination.

<snip>
```

Here's my build environment:

```
$ hugo env                       
hugo v0.148.2+extended+withdeploy linux/amd64 BuildDate=2025-07-27T12:43:24Z VendorInfo=brew
GOOS="linux"
GOARCH="amd64"
GOVERSION="go1.24.5"
github.com/sass/libsass="3.6.6"
github.com/webmproject/libwebp="v1.3.2"
```

## Solution

Define [`outputs`](https://gohugo.io/configuration/outputs/#outputs-per-page) in the metadata of the pages that are intended for HTML content only. I've tested this to work on my local development server, confirming that pages still navigate and that plaintext, Markdown, and AsciiDoc versions of Contributor Covenant versions are availavle with accurate `Content-Type` response headers.

## Todo

Sit back and enjoy warning-free builds. :)

## Notes for Reviewers

Thanks for looking! <3
