### PR TITLE
Add IBM to featured adopters

### DIFF
--- a/assets/featured-adopters.csv
+++ b/assets/featured-adopters.csv
@@ -1,68 +1,44 @@
 project,url
-Atom, https://github.com/atom/atom
-Angular, https://github.com/angular/code-of-conduct
-Babel, https://github.com/babel/babel
 Bootstrap, https://github.com/twbs/bootstrap
 BBC, https://www.bbc.co.uk/opensource
 Bundler, https://github.com/rubygems/bundler
-chef-rvm, https://github.com/sous-chefs/rvm
 Cloud Native Compute Foundation, https://www.cncf.io/
 CocoaPods, https://github.com/cocoapods/cocoapods
 code.gov, https://github.com/GSA/code-gov/
 Creative Commons, http://opensource.creativecommons.org/community/code-of-conduct/
-Cucumber, https://github.com/cucumber
 Crystal, https://github.com/crystal-lang/crystal
 curl, https://github.com/curl/curl
-Diaspora, https://github.com/diaspora/diaspora
-Discourse, https://github.com/discourse/discourse
-Eclipse, https://www.eclipse.org/
-Electron, https://github.com/electron/electron
 Elixir, https://github.com/elixir-lang/elixir
 Exercism.io, https://github.com/exercism/exercism
-Flickr, https://blog.flickr.net/en/2022/02/14/safer-internet-day-and-open-source-codes-of-conduct/
-Gatsby, https://github.com/gatsbyjs/gatsby
 git, https://github.com/git/git
 GitLab, https://gitlab.com/gitlab-org/gitlab-foss/
 Golang, https://golang.org/conduct
 Google, https://opensource.google/docs/releasing/template/CODE_OF_CONDUCT/
-Homebrew-Cask, https://github.com/Homebrew/homebrew-cask
+IBM, https://github.com/IBM/repo-template
 Intel OTC, https://01.org/blogs/2018/intel-covenant-code
-Jekyll, https://github.com/jekyll/jekyll
 Jenkins, https://www.jenkins.io/conduct/
 JRuby, https://github.com/jruby/jruby/
-JSON Schema, https://github.com/json-schema-org/json-schema-spec
 JuneteenthConf, https://juneteenthconf.com/
 Hanami, http://hanamirb.org/community/#code-of-conduct
-Kong, https://github.com/Kong/kong/
 Kubernetes, https://github.com/kubernetes/kubernetes/
 Linux, https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=8a104f8b5867c682d994ffa7a74093c54469c11f
 Mastodon, https://github.com/mastodon/mastodon
 Metasploit Framework, https://github.com/rapid7/metasploit-framework
 Microsoft, https://opensource.microsoft.com/codeofconduct/
-Mono, https://github.com/mono/mono
-Mozilla Webmaker, https://foundation.mozilla.org/en/artifacts/webmaker/
 .NET Foundation, https://dotnetfoundation.org/about/code-of-conduct
-next.js, https://nextjs.org
 Node.js, https://github.com/nodejs
 Rails, https://github.com/rails/rails
 rbenv, https://github.com/rbenv/rbenv
 React, https://github.com/facebook/react
-ROM, https://github.com/rom-rb/rom
 RSpec, https://github.com/rspec/rspec
-ruby-community, https://github.com/ruby-community/ruby-community
-rubygems, https://github.com/rubygems/rubygems
 RubyGems.org, https://github.com/rubygems/rubygems.org
 RVM, https://github.com/rvm/rvm
 Salesforce OSS, https://github.com/salesforce/oss-template
-Shoes, https://github.com/shoes/shoes4
-Spring, https://github.com/spring-projects
 Swift, https://swift.org/community/#code-of-conduct
-Symfony, https://github.com/symfony/symfony
 Target, https://github.com/target
 TensorFlow, https://github.com/tensorflow/tensorflow
 Travis CI, https://travis-ci.community/t/code-of-conduct/64
 Twilio, https://github.com/twilio
 Visual F#, https://github.com/dotnet/fsharp
-Vue.js, https://github.com/vuejs/vue
 WordPress, https://make.wordpress.org/handbook/community-code-of-conduct/
 Yarn, https://github.com/yarnpkg/yarn


### PR DESCRIPTION
## Problem
IBM was listed as an adopter, but not a featured adopter.

## Solution
Add them to the CSV data file.

## Notes for Reviewers
I also cleaned up the Featured Adopters list a bit.