### PR TITLE
Update writingDirection to languageDirection

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -49,7 +49,7 @@ languageCode = "am"
 [Languages.ar]
 languageName = "العربية"
 languageCode = "ar"
-writingDirection = "rtl"
+languageDirection = "rtl"
 
 [Languages.bn]
 languageName = "Bengali"
@@ -119,7 +119,7 @@ languageCode = "it"
 [Languages.iw]
 languageName = "עברית"
 languageCode = "iw"
-writingDirection = "rtl"
+languageDirection = "rtl"
 
 [Languages.ja]
 languageName = "日本語"
@@ -141,8 +141,8 @@ languageCode = "ko"
 languageName = "Македонски"
 languageCode = "mk"
 
-[Languages.ms] 
-languageName = "Malaysia" 
+[Languages.ms]
+languageName = "Malaysia"
 languageCode = "ms"
 
 [Languages.nl]
@@ -196,7 +196,7 @@ languageCode = "zh-cn"
 [Languages.fa-IR]
 languageName = "فارسی"
 languageCode = "fa-IR"
-writingDirection = "rtl"
+languageDirection = "rtl"
 
 [Languages.sw]
 languageName = "Swahili"

--- a/layouts/version/single.html
+++ b/layouts/version/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-<section class="version" {{ with .Language.Params.writingDirection }} dir="{{ . }}"{{ end }}>
+<section class="version" {{ with .Language.LanguageDirection }} dir="{{ . }}"{{ end }}>
 {{ .Content }}
 </section>
 <section class="formats">

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -186,9 +186,10 @@ ol {
   margin: 0 0 0 1.5rem;
 }
 
-[dir="rtl"] ul,
-[dir="rtl"] ol {
+ul:dir(rtl),
+ol:dir(rtl) {
   margin: 1.5rem 1.5rem 1.5rem 0;
+  list-style-position: inherit;
 }
 
 li {
@@ -769,10 +770,18 @@ area {
   font-size: 1rem;
 }
 
+.version:dir(rtl) {
+  text-align: right;
+}
+
 .preview p, .version p {
   text-align: left;
   width: 100%;
   margin: 1rem 0;
+}
+
+.preview p:dir(rtl), .version p:dir(rtl) {
+  text-align: right;
 }
 
 .preview h1, .versiom h1 {
@@ -798,6 +807,10 @@ area {
 
 .preview ul, .version ul {
   margin: 0 0 0 0;
+}
+
+.preview ul:dir(rtl), .version ul:dir(rtl) {
+  margin: 1.5rem 1.0rem 1.5rem 0;
 }
 
 .preview li, .version li {
@@ -837,6 +850,10 @@ area {
     list-style: none;
     padding: 0;
     text-align: left;
+  }
+
+  nav ul:dir(rtl) {
+    text-align: right;
   }
 
   nav ul li {


### PR DESCRIPTION
We welcome sincere, human contributions that align with our [guidelines](https://github.com/EthicalSource/contributor_covenant/blob/release/CONTRIBUTING.md). All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/EthicalSource/contributor_covenant/blob/release/CODE_OF_CONDUCT.md). AI-generated pull requests will be reported as spam and closed without comment.

## Problem
As reported in #1530 , right-to-left layout support was broken, resulting in pages like the Arabic translation displaying incorrectly as left-to-right.

## Solution
The problem ended up being an issue related to the hugo upgrade that came with the site redesign. Writing direction had previously been indicated in the configuration file with `writingDirection`, but that was deprecated at some point. The new attribute name is `languageDirection`. All I had to do was find-and-replace these two attribute names in `hugo.toml`.
