### PR TITLE
Remove BBC from adopters & featured adopters

### DIFF
--- a/assets/adopters.csv
+++ b/assets/adopters.csv
@@ -32,7 +32,6 @@ Babel, https://github.com/babel/babel
 Backlight deb packages, https://github.com/gorlapraveen/blacklight-deb-packages
 Baleen CLI, https://github.com/baleen/cli
 Baleen Migrations, https://github.com/baleen/migrations
-BBC, https://www.bbc.co.uk/opensource
 BcnEng, https://bcneng.org
 Beagle Framework,https://github.com/ZupIT/beagle
 Bearsampp, https://bearsampp.com/code-of-conduct

--- a/assets/featured-adopters.csv
+++ b/assets/featured-adopters.csv
@@ -1,6 +1,5 @@
 project,url
 Bootstrap, https://github.com/twbs/bootstrap
-BBC, https://www.bbc.co.uk/opensource
 Bundler, https://github.com/rubygems/bundler
 Cloud Native Compute Foundation, https://www.cncf.io/
 CocoaPods, https://github.com/cocoapods/cocoapods


### PR DESCRIPTION
The BBC has often published transphobic news articles. For example a 2025 review of a TV show focussed on a trans woman leads with a quote about how trans women are “biological men”, and quotes a well known UK transphobic campaigner who calls trans women “delusional”. I do not think the BBC actually following this contributor convenant. Perhaps they were in the past. Since they're not following it, I propose they be removed.

https://www.bbc.com/news/articles/c70zd31n2k0o
cf. #1225 #1232 #1296

## Problem
The [homepage](https://www.contributor-covenant.org/) lists the BBC prominantly, despite the BBC publishing transphobic news articles.

## Solution
Remove reference.

## Todo
I think none.

## Notes for Reviewers
Nope. 🙂
