### PR TITLE
Remove contact form in favor of email address due to spam

### DIFF
--- a/content/contact.html
+++ b/content/contact.html
@@ -7,65 +7,6 @@ outputs = ["html"]
 
 <h1>Contact Us</h1>
 
-<form class="send_message_form message form" name="contact-form" method="post" action="/contact-thanks" data-modal-id="modal-notify" data-netlify="true" netlify-honeypot="bot-field">
-  <div class="form-group">
-    <label class="hidden">
-      <input name="bot-field">
-      <input name="subject" value="Contributor Covenant Contact Form">
-    </label>
-  </div>
-  <div class="form-group">
-    <label>
-      <p>Name</p>
-      <input name="name" type="text" required>
-    </label>
-  </div>
-  <div class="form-group">
-    <label>
-      <p>E-mail</p>
-      <input name="email" type="email" required>
-    </label>
-  </div>
-
-  <div class="form-group">
-    <label>
-      <p>
-        Message
-      </p>
-      <textarea name="message" required></textarea>
-    </label>
-  </div>
-  <fieldset>
-    <button type="submit" class="button">Send</button>
-  </fieldset>
-</form>
-
-<p id="confirmation-message" class="hidden">
-  <em>Thank you for your message. It has been directed to the volunteer-led Contributor Covenant Working Group at the Organization for Ethical Source. We will respond as promptly as we can.</em>
+<p>
+  Contributor Covenant is stewarded by the <a href="https://ethicalsource.dev">Organization for Ethical Source</a>. To get in touch with the working group, send a message to <em>info@ethicalsource.dev</em>.
 </p>
-
-<script language="javascript">
-
-  const handleSubmit = (event) => {
-    event.preventDefault();
-
-    const myForm = event.target;
-    const formData = new FormData(myForm);
-
-    fetch("/", {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: new URLSearchParams(formData).toString(),
-    })
-      .then(() => toggleConfirm())
-      .catch((error) => alert(error));
-  };
-
-  document.querySelector("form").addEventListener("submit", handleSubmit);
-
-  function toggleConfirm() {
-    document.querySelector("form").style.display = "none";
-    document.getElementById("confirmation-message").style.display = "block";
-  }
-
-</script>

--- a/layouts/_partials/footer.html
+++ b/layouts/_partials/footer.html
@@ -17,7 +17,7 @@
     <div class="nav-card">
       <h3>Contact Us</h3>
       <p>
-        <a href="/contact">Send a message</a>
+        info@ethicalsource.dev
       </p>
 
       <h4>Social</h4>


### PR DESCRIPTION
We welcome sincere, human contributions that align with our [guidelines](https://github.com/EthicalSource/contributor_covenant/blob/release/CONTRIBUTING.md). All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/EthicalSource/contributor_covenant/blob/release/CODE_OF_CONDUCT.md). AI-generated pull requests will be reported as spam and closed without comment.

## Problem
The new website is being overwhelmed by spam through the contact form, and the honeypot field our hosting provider provides is no longer filtering it out.

## Solution
Replace the contact form with an email address. That has spam filtering.