### PR TITLE
Update hugo from v0.148.2 to v0.152.2

### DIFF
--- a/.netlify.toml
+++ b/.netlify.toml
@@ -3,4 +3,4 @@
   publish = "public"
 
 [build.environment]
-  HUGO_VERSION = "0.148.2"
+  HUGO_VERSION = "0.152.2"


### PR DESCRIPTION
Hello hello! I have some free time, so I'm doing a dependency check across our projects. This PR updates Netlify's version of Hugo to the current version v0.152.2.

The features introduced between v0.148.2 and v0.152.2 don't affect the site, though there are a number of transient dependency updates that bypass a few CVEs (that also don't affect the site).

Thanks for looking! <3