### PR TITLE
Update the link to new adopter instructions

### DIFF
--- a/content/adopters.html
+++ b/content/adopters.html
@@ -8,7 +8,7 @@ outputs = ["html"]
 <h1>Featured Contributor Covenant Adopters</h1>
 
 <p>
-  Want to add your project, community, or event to this list? Follow the instructions in our <a href="https://github.com/EthicalSource/contributor_covenant/blob/release/README.md#registering-your-community-as-an-adopter">README</a> to let us know about your adoption!
+  Want to add your project, community, or event to this list? Follow the instructions in our <a href="https://github.com/EthicalSource/contributor_covenant/blob/release/CONTRIBUTING.md#adding-your-community-to-the-list-of-adopters">contribution guide</a> to let us know about your adoption!
 </p>
 
 {{< adopters "featured-adopters.csv" >}}


### PR DESCRIPTION
Hi again!

While validating site functionality in a previous change I noticed that the instructions link on the [featured adopters page](https://www.contributor-covenant.org/adopters/) was incorrect. This PR updates it to the relevant section in `CONTRIBUTING.md`: https://github.com/EthicalSource/contributor_covenant/blob/release/CONTRIBUTING.md#adding-your-community-to-the-list-of-adopters

Thanks a lot!