### PR TITLE
Replace 'Community Manager' with 'Community Moderator'

### DIFF
--- a/content/version/3/0/code_of_conduct.md
+++ b/content/version/3/0/code_of_conduct.md
@@ -82,7 +82,7 @@ If an investigation by the Community Moderators finds that this Code of Conduct 
    2) Consequence: Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
    3) Repair: There is no possible repair in cases of this severity.
 
-This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.
+This enforcement ladder is intended as a guideline. It does not limit the ability of Community Moderators to use their discretion and judgment, in keeping with the best interests of our community.
 
 
 ## Scope


### PR DESCRIPTION
## Problem

This is the only place the term 'Community Manager' appears in the code of conduct, and there is no clear distinction from 'Community Moderator' which is used throughout.

On that basis I believe that 'Community Manager' is a typo.

## Solution

Replaced the only instance of 'Community Manager' with 'Community Moderator'.

## Todo

N/A

## Notes for Reviewers

If 'Community Manager' is intended to be defined as a separate role, it would be good to clarify the roles somewhere in the code of conduct, or at least make it clear why it is a separate person / role.
