### PR TITLE
Add preCICE to adopters (and fix path in CONTRIBUTING.md)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Check the [issues](https://github.com/EthicalSource/contributor_covenant/issues)
 ## Adding Your Community to the List of Adopters
 
 * Fork the repository.
-* Edit the `static/adopters.csv` file
+* Edit the `assets/adopters.csv` file
 * Add a row with your project or community name in the first column, and its URL in the second column.
 * For human readability, please make sure that you've preserved alphabetical order in the list.
 * Open a pull request.

--- a/assets/adopters.csv
+++ b/assets/adopters.csv
@@ -311,6 +311,7 @@ Power Ampache 2, https://power.ampache.dev
 prance (Resolving Swagger/OpenAPI 2.0 Parser), https://github.com/jfinkhaeuser/prance
 PRAW, https://github.com/praw-dev/praw
 Pre-filled repository, https://github.com/GuglielmoPepe/pre-filled-repository
+preCICE, https://precice.org/
 Pressbooks, https://github.com/pressbooks/pressbooks
 Prettier, https://prettier.io
 ProcessIterator, https://github.com/console-helpers/process-iterator


### PR DESCRIPTION
1. Adds [preCICE](https://precice.org/) to the adopters
   - Code of conduct: https://github.com/precice/precice/blob/develop/CODE_OF_CONDUCT.md
   - Referenced from: https://precice.org/community-channels.html
2. Fixes the path to the respective file in `CONTRIBUTING.md` (was `static/adopters.csv`, but now `assets/adopters.csv`, since https://github.com/EthicalSource/contributor_covenant/commit/e0324b3cc9df5f3a62b6027157d8c2da5e0f6d68.