### PR TITLE
chore: prefer 'GitHub' over 'Github'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Please feel free to submit pull requests or open issues to improve Contributor Covenant, whether through code, content, design, or [translations](https://www.contributor-covenant.org/translations).
 
-If you're new to contributing to projects hosted on Github, or need a refresher, you may find [How to make your first pull request on GitHub](https://www.freecodecamp.org/news/how-to-make-your-first-pull-request-on-github-3/) a useful resource.
+If you're new to contributing to projects hosted on GitHub, or need a refresher, you may find [How to make your first pull request on GitHub](https://www.freecodecamp.org/news/how-to-make-your-first-pull-request-on-github-3/) a useful resource.
 
 Check the [issues](https://github.com/EthicalSource/contributor_covenant/issues) for the latest discussions involving the current and future versions of the Contributor Covenant. If your question, concern, or suggestion is not already listed, please open a new issue using the **New Issue** button, and select either the **🪲Bug Report** or **💡Feature Request** template.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -12,7 +12,7 @@ Contributor Covenant ignited a revolution in how we think about open source comm
 # Decision-making
 
 ## Lazy consensus
-Most decisions, such as approval of minor copy edits or the addition of a translation, are made in public through comments on pull requests or issues on our Github repository. Decisions about such changes are presumed to pass in the absence of objections.
+Most decisions, such as approval of minor copy edits or the addition of a translation, are made in public through comments on pull requests or issues on our GitHub repository. Decisions about such changes are presumed to pass in the absence of objections.
 
 ## Committee responsibilities
 In case of major changes, or conflict that contributors cannot resolve themselves, the OES's Board has the responsibility for final decision-making.

--- a/content/translations.html
+++ b/content/translations.html
@@ -20,6 +20,6 @@ outputs = ["html"]
 
 <div class="banner banner-takeover">
   <p>
-    We're always looking for new translations of Contributor Covenant and are thankful for the volunteers who contribute their time to this effort. <a href="https://github.com/EthicalSource/contributor_covenant#translating">Instructions for translators</a> are available in our Github project.
+    We're always looking for new translations of Contributor Covenant and are thankful for the volunteers who contribute their time to this effort. <a href="https://github.com/EthicalSource/contributor_covenant#translating">Instructions for translators</a> are available in our GitHub project.
   </p>
 </div>


### PR DESCRIPTION
This PR fixes an incorrect capitalization of [**GitHub**](https://en.wikipedia.org/wiki/GitHub).

Although non-functional, consistency in naming reduces visual noise, prevents propagation of small errors, and keeps documentation aligned with upstream conventions.

