### PR TITLE
feat: add invisible-squiggles to adopters

### DIFF
--- a/assets/adopters.csv
+++ b/assets/adopters.csv
@@ -191,6 +191,7 @@ IBM, https://github.com/IBM/repo-template
 icepyx, https://github.com/icesat2py/icepyx
 if me, https://github.com/ifmeorg/ifme
 Intel OTC, https://01.org/blogs/2018/intel-covenant-code
+invisible-squiggles, https://github.com/michen00/invisible-squiggles
 irhamdzuhri.com, https://github.com/irhamdz/irhamdzuhri.com
 iText, https://itextpdf.com/en
 Ivy Framework, https://github.com/Ivy-Interactive/Ivy-Framework

--- a/assets/adopters.csv
+++ b/assets/adopters.csv
@@ -208,13 +208,13 @@ JRuby, https://github.com/jruby/jruby/
 JSON Schema, https://github.com/json-schema-org/json-schema-spec
 json-rpc, https://github.com/pavlov99/json-rpc
 JuneteenthConf, https://juneteenthconf.com/
-Kowalski Telegram Bot, https://github.com/abocn/TelegramBot
 Keptn, https://keptn.sh/
 Kibi, https://github.com/ilai-deutel/kibi
 Kickoff, https://github.com/TryKickoff/kickoff/
 Kiva, https://github.com/kiva
 Kong, https://github.com/Kong/kong/
 Kornia, https://github.com/kornia/kornia
+Kowalski Telegram Bot, https://github.com/abocn/TelegramBot
 Kubernetes, https://github.com/kubernetes/kubernetes/
 LA Devs, https://github.com/la-devs/ladevs.org
 Laravel.io, https://github.com/laravelio/laravel.io
@@ -295,8 +295,8 @@ Perfect, https://github.com/PerfectlySoft/Perfect
 PeteBishwhip, https://github.com/PeteBishwhip/
 Pexip - Video Conferencing SDK, https://github.com/pexip/pexkit-sdk
 pg_chameleon - MySQL to PostgreSQL replica, https://github.com/the4thdoctor/pg_chameleon
-phpMyAdmin, https://www.phpmyadmin.net/
 PHP-CSS-Parser, https://github.com/MyIntervals/PHP-CSS-Parser
+phpMyAdmin, https://www.phpmyadmin.net/
 PHPStan, https://phpstan.org/
 Phylum CI, https://github.com/phylum-dev/phylum-ci
 pimutils, https://pimutils.org/coc/

--- a/assets/featured-adopters.csv
+++ b/assets/featured-adopters.csv
@@ -1,4 +1,5 @@
 project,url
+.NET Foundation, https://dotnetfoundation.org/about/code-of-conduct
 Bootstrap, https://github.com/twbs/bootstrap
 Bundler, https://github.com/rubygems/bundler
 Cloud Native Compute Foundation, https://www.cncf.io/
@@ -13,18 +14,17 @@ git, https://github.com/git/git
 GitLab, https://gitlab.com/gitlab-org/gitlab-foss/
 Golang, https://golang.org/conduct
 Google, https://opensource.google/docs/releasing/template/CODE_OF_CONDUCT/
+Hanami, http://hanamirb.org/community/#code-of-conduct
 IBM, https://github.com/IBM/repo-template
 Intel OTC, https://01.org/blogs/2018/intel-covenant-code
 Jenkins, https://www.jenkins.io/conduct/
 JRuby, https://github.com/jruby/jruby/
 JuneteenthConf, https://juneteenthconf.com/
-Hanami, http://hanamirb.org/community/#code-of-conduct
 Kubernetes, https://github.com/kubernetes/kubernetes/
 Linux, https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=8a104f8b5867c682d994ffa7a74093c54469c11f
 Mastodon, https://github.com/mastodon/mastodon
 Metasploit Framework, https://github.com/rapid7/metasploit-framework
 Microsoft, https://opensource.microsoft.com/codeofconduct/
-.NET Foundation, https://dotnetfoundation.org/about/code-of-conduct
 Node.js, https://github.com/nodejs
 rbenv, https://github.com/rbenv/rbenv
 React, https://github.com/facebook/react


### PR DESCRIPTION
- Project: [Invisible Squiggles](https://marketplace.visualstudio.com/items?itemName=michen00.invisible-squiggles)
- Repo: (invisible-squiggles](https://github.com/michen00/invisible-squiggles)
- Project Code of Conduct: [Contributor Covenant v3.0](https://github.com/michen00/invisible-squiggles?tab=coc-ov-file)

Note that the Code of Conduct is stored [elsewhere](https://github.com/michen00/.github/blob/main/CODE_OF_CONDUCT.md) and referenced in as a [GitHub default community health file](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file).

---

I also resorted `assets/adopters.csv` and `assets/featured-adopters.csv`.