### PR TITLE
Add SAP to list of adopters

### DIFF
--- a/assets/adopters.csv
+++ b/assets/adopters.csv
@@ -356,6 +356,7 @@ RubyGems.org, https://github.com/rubygems/rubygems.org
 RVM, https://github.com/rvm/rvm
 Salesforce OSS, https://github.com/salesforce/oss-template
 SaltStack, https://github.com/saltstack/salt
+SAP, https://github.com/SAP
 Sass Guidelines, https://github.com/HugoGiraudel/sass-guidelines
 SassDoc, https://github.com/sassdoc/sassdoc
 Scrapy, https://scrapy.org/


### PR DESCRIPTION
We welcome sincere, human contributions that align with our [guidelines](https://github.com/EthicalSource/contributor_covenant/blob/release/CONTRIBUTING.md). All contributions, including pull requests, issues, and comments, are governed by our [code of conduct](https://github.com/EthicalSource/contributor_covenant/blob/release/CODE_OF_CONDUCT.md). AI-generated pull requests will be reported as spam and closed without comment.

## Problem
SAP is not mentioned in the list of adopters, though we have been using the Contributor Covenant since several years, see for instance https://github.com/SAP/.github/blob/main/CODE_OF_CONDUCT.md

## Solution
SAP is added to the list of adopters.

## Todo
None

## Notes for Reviewers
Thanks for your work!
