### PR TITLE
Update resources.html to use the published GDoc link for Transforming Tension and Conflict

### DIFF
--- a/content/resources.html
+++ b/content/resources.html
@@ -53,7 +53,7 @@ outputs = ["html"]
   </li>
 <li>
     <p>
-      <a href="https://docs.google.com/document/d/1X4yfSo0lQpYTtWMqqKf42YFCtfKeLMA13bvyq6N13Pg/edit?usp=sharing" title="Transforming Tension and Conflict">Transforming Tension and Conflict</a>
+      <a href="https://docs.google.com/document/d/e/2PACX-1vTW6wgXUz8w5LIVu-Vz8XlIfS-6NxV2FZ3JjpLEOgIfSgR4UV8gZDv2B8965anda6mJsqW6LUuSvpek/pub" title="Transforming Tension and Conflict">Transforming Tension and Conflict</a>
       <br />
       (by Inclusive Organizing)
     </p>


### PR DESCRIPTION
## Problem 
Strangers occasionally request the ability to directly edit _Transforming Tension and Conflict_.  I guess that they accidentally bump the prominent "Request Edit Access" button on the standard GDoc interface.

## Solution
I changed the GDoc link to a published version, instead of the standard publicly-viewable doc.  The published version looks almost identical and has the exact same content, but doesn't have the "Request Edit Access" button.