### PR TITLE
Translate the 3.0 version to French

### DIFF
--- a/content/version/3/0/code_of_conduct.fr.md
+++ b/content/version/3/0/code_of_conduct.fr.md
@@ -1,0 +1,92 @@
++++
+version = "3.0"
+aliases = ["/version/3/0/fr"]
+reportingPlaceholder = "[NOTE: décrivez par quel moyen rapporter les faits ici.]"
+enforcementPlaceholder = "[NOTE: Les résolutions et réparations soulignées dessous ne sont que des suggestions proposées pour l'application du code de conduite. Si votre communauté a son propre mode d'application, adaptez cette section pour décrire vos pratiques.]"
++++
+
+# Code de conduite 3.0 _Contributor Covenant_
+
+## Notre engagement
+
+Nous nous engageons à faire de notre communauté un espace accueillant, positif, et équitable pour toutes et tous.
+
+Nous sommes dédiés à encourager un environnement qui respecte et valorise la dignité, les droits, les contributions de tous les individus, quelque soit leurs caractéristiques comme l'origine, l'ethnicité, la classe sociale, la couleur de peau, l'âge, l'apparence physique, la neurodiversité, le handicap, le sexe ou le genre, l'identité ou l'expression de genre, l'orientation sexuelle, la langue, la spiritualité ou religion, l'origine sociale ou nationale, la position socio-économique, le niveau d'éducation, ou autre statut. Les mêmes droits à la participation sont offerts à tous·te les participant·es de bonne foi et en accord avec cet engagement.
+
+## Comportements valorisés
+
+Tout en reconnaissant les différences entre les normes sociales, nous nous efforçons chacun·e pour pousser les attentes de notre communauté vers des comportements positifs. Nous comprenons aussi que nos mots et actions peuvent être interprétés différemment de notre intention initiale, selon la culture, le vécu ou la langue natale.
+
+Avec ces considérations en tête, nous acceptons de nous comporter consciencieusement entre nous, et d'agir de manière à favoriser nos valeurs communes, incluant:
+
+1. Respecter **la raison d'être de notre communauté**, nos activités, et nos manières de nous réunir.
+2. Dialoguer de manière **bienveillante et honnête** avec les autres.
+3. Respecter les **différences de point de vue** et les ressentis.
+4. **Prendre la responsabilité** de nos actes et contributions.
+5. Donnez et recevoir les **critiques constructives** avec dignité.
+6. S'engager à **réparer nos torts** une fois fait.
+7. Bien se tenir pour favoriser et maintenir un **environnement sain pour notre communauté**
+
+## Comportements interdits
+
+Nous acceptons de restreindre les comportements suivants au sein de notre communauté. Commettre, menacer de, ou faire la promotion des comportements suivants sont des infractions au Code de Conduite.
+
+1. **Harcèlement.** Outrepasser les limites exprimées ou solliciter une attention inutile après une demande claire de cesser.
+2. **Attaque personnelle.** Insulter, dévaloriser, ou faire des commentaires désobligeant envers une personne de la communauté ou un groupe de personne.
+3. **Stéréotype ou discrimination.** Réduire la personnalité ou le comportement de quiconque sur la base de caractères identitaires ou innés.
+4. **Sexualisation.** Se comporter de manière inappropriée et trop intime pour le contexte ou la raison d'être de la communauté.
+5. **Effraction de confidentialité.** Divulguer ou agir sur un fait personnel ou privé sans l'accord de la personne.
+6. **Mise en danger.** Provoquer, encourager, attiser la violence ou une autre nuisance sur une personne ou un groupe.
+7. Se comporter d'une manière qui **nuit au vivre-ensemble** de la communauté.
+
+## Autres Restrictions
+
+1. **Usurpation d'identité.** Se faire passer pour quelqu'un d'autre sans raison, ou prétendre être quelqu'un d'autre pour éviter des sentences.
+2. **Refuser de créditer ses sources.** Ne pas créditer correctement les sources des contenus que vous avancez.
+3. **Support publicitaire.** Partager des contenus marketing ou promotionnels d'une manière qui outrepasse les normes de la communauté.
+4. **Communication irresponsable.** Échouer à présenter de manière responsable du contenu incluant, reliant ou retraçant une autre infraction.
+
+## Rapporter un Problème
+
+Des tensions peuvent se produire entre les membres de la communauté même lorsque iels font de leur mieux pour collaborer. Tous les conflits ne représentent pas une infraction au code de conduite, et ce Code de Conduite encourage les comportements et normes qui aident à éloigner les conflits, et à minimiser les douleurs.
+
+Lorsqu'un problème se produit, il est important de le notifier rapidement. Pour rapporter une possible infraction, **[NOTE: décrivez par quel moyen rapporter les faits ici.]**
+
+La modération de la communauté recueille les infractions sérieusement et fait tout son possible pour répondre rapidement. Les modérateur.ices examinerons toutes plaintes d'infraction au code de conduite, vérifieront les messages, les évènements, les enregistrements, solliciteront des témoins ou autres participants. La modération de la communauté gardera l'investigation et la prise de mesures aussi transparente que possible, tout en priorisant la sécurité et la confidentialité. Dans le but d'honorer ces engagements, les mesures prises sont portées de manière privée aux parties concernées, mais communiquer au reste de la communauté peut faire partie de la résolution convenue conjointement.
+
+## Résolution et Réparation des Torts
+
+**[NOTE: Les résolutions et réparations soulignées dessous ne sont que des suggestions proposées pour l'application du code de conduite. Si votre communauté a son propre mode d'application, adaptez cette section pour décrire vos pratiques.]**
+
+Si l'enquête par les modérateur·ices évalue que ce Code de Conduite a été enfreint, la grille de mesures suivante peut être utilisé pour déterminer comment réparer au mieux les torts, en se basant sur l'impact de l'incident sur les individus concernés et la communauté entière. En fonction de la sévérité de l'infraction, les premières étapes peuvent être sautées.
+
+1) Avertissement
+   1) Cas: Une infraction concernant un unique incident, ou des séries d'incidents isolés.
+   2) Conséquences: Un avertissement privé, écrit de la part des modérateur·ices.
+   3) Réparation: Une réparation comprend des excuses écrites privées, une reconnaissance de responsabilité, et la recherche d'éclaircissement sur les attendus.
+2) Limitation d'activité temporaire
+   1) Cas: La répétition d'infractions qui ont déjà donné lieu à des avertissements, ou le premier incident d'une infraction plus importante.
+   2) Conséquences: Un avertissement privé écrit accompagné d'une période de retour au calme pour mettre en évidence l'importance de la situation et donner à la communauté le temps d'intégrer ce qui s'est passé. Ce temps de réflexion peut être limité à certains canaux de communication ou aux interactions avec certains membres de la communauté.
+   3) Réparation: Une réparation peut inclure la formulation d'excuses, l'utilisation d'un temps de retour au calme pour réfléchir aux actions et conséquences, et être plus consciencieu·se après la fin de la période, au retour dans les espaces communautaires.
+3) Suspension provisoire
+  1) Cas: Un schéma de répétition d'infraction auquel les modérateur·ices ont adressé des avertissements, ou une seule infraction d'importance.
+  2) Conséquences: Un avertissement privé écrit informant des conditions de retour de suspension. En général, une suspension provisoire donne à la personne suspendue le temps d'introspection sur son comportement et sur les corrections qu'elle doit entreprendre.
+  3) Réparation: Une réparation peut inclure la compréhension du motif de la suspension, le respect des conditions de retour, et réfléchir à comment réintégrer la communauté lorsque la suspension sera levé.
+4) Bannissement permanent
+  1) Cas: Un schéma de répétition d'infractions du Code de Conduite où les premières étapes de résolution ont échoué, ou une infraction tellement importante que les modérateur·ices de la communauté déterminent qu'il n'y a aucun moyen de maintenir un espace communautaire sûr avec cette personne comme membre.
+  2) Conséquences: L'accès aux espaces communautaires, les outils, les canaux de communication sont révoqués. En général, les bannissements permanents devraient être rare, et doivent être appuyés de raisons fortes, et être le dernier recourt lorsque toutes les solutions ont échoué à corriger le comportement.
+  3) Réparation: Il n'y a aucune réparation possible pour des cas de cette sévérité.
+
+Cette échelle de mesure est une ligne directrice. Elle ne limite pas la capacité des modérateur·ices à utiliser leurs discrétions et leurs jugements, en adéquation avec l'intérêt de la communauté.
+
+## Portée
+
+Ce Code de Conduite s'applique au sein des espaces communautaires, et s'applique également lorsqu'un individu représente officiellement la communauté auprès du public ou dans un autre espace. La représentation de la communauté inclut l'utilisation d'adresse e-mail officielle, les posts via un compte officiel d'un réseau social, ou agir en tant que représentant élu lors d'un évènement en ligne ou non.
+
+## Attributions
+
+Ce Code de Conduite est adapté du _Contributor Covenant_, version 3.0, disponible ici [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
+
+Le _Contributor Covenant_ est géré par l'_Organization for Ethical Source_ et sous licence CC BY-SA 4.0. Pour accéder à une copie de cette licence, visitez [https://creativecommons.org/licenses/by-sa/4.0/deed.fr](https://creativecommons.org/licenses/by-sa/4.0/deed.fr).
+
+Pour répondre aux questions fréquentes à propos du _Contributor Covenant_, consultez la FAQ ici [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Des traductions sont fournie ici [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Des mesures additionnelles et des lignes directrices de communauté peuvent être trouvé ici [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources). L'échelle des mesures est inspirée par le travail de [l'équipe du code de conduite de Mozilla](https://github.com/mozilla/inclusion).


### PR DESCRIPTION
We expect to use an adapted version of the Contributor Covenant CoC, as a baseline ruleset at my worker cooperative (https://calinou.coop/), but we lack a french version of it.

Here is a translation of the 3.0 version to French. This has been co-authored with @ErynnV.