### PR TITLE
Adding Django Project to the adopters list

### DIFF
--- a/assets/adopters.csv
+++ b/assets/adopters.csv
@@ -107,6 +107,7 @@ Deviser Platform, https://github.com/deviserplatform/deviserplatform
 Diaspora, https://github.com/diaspora/diaspora
 Discourse, https://github.com/discourse/discourse
 Diversity Handbook, https://github.com/DanRoeSparks/diversity-handbook
+Django Project, https://github.com/django/code-of-conduct
 Dokku, https://github.com/dokku/dokku
 Doublify, https://github.com/doublify
 Drachenhorn, https://github.com/Drachenhorn-Team/Drachenhorn

--- a/assets/featured-adopters.csv
+++ b/assets/featured-adopters.csv
@@ -8,6 +8,7 @@ code.gov, https://github.com/GSA/code-gov/
 Creative Commons, http://opensource.creativecommons.org/community/code-of-conduct/
 Crystal, https://github.com/crystal-lang/crystal
 curl, https://github.com/curl/curl
+Django Project, https://github.com/django/code-of-conduct
 Elixir, https://github.com/elixir-lang/elixir
 Exercism.io, https://github.com/exercism/exercism
 git, https://github.com/git/git


### PR DESCRIPTION
Following the merging of https://github.com/django/code-of-conduct/pull/97 with approval of the Django Software Foundation Board the Django Project has adopted Contributor Covenant 3. Thank you all for the work you've put into this!