### PR TITLE
Add Spanish translation of Code of Conduct version 3.0

### DIFF
--- a/content/version/3/0/code_of_conduct.es.md
+++ b/content/version/3/0/code_of_conduct.es.md
@@ -1,0 +1,98 @@
++++
+title = "Contributor Covenant 3"
+version = "3.0"
+aliases = ["/version/3/0"]
+reportingPlaceholder = "[NOTA: describa de qué manera se puede reportar aquí.]"
+enforcementPlaceholder = "[NOTA: Las medidas y reparaciones descritas a continuación son sugerencias basadas en buenas prácticas para seguir nuestros códigos de conducta. Si tu comunidad tiene su propio proceso establecido, edita esta sección para describir tus propias políticas.]"
++++
+
+# Código de Conducta para Contribuyentes, versión 3.0
+
+## Nuestro compromiso
+
+Nos comprometemos a hacer de nuestra comunidad un espacio abierto, seguro y equitativo para todas las personas.
+
+Estamos comprometidos a fomentar un entorno que respete y promueva la dignidad, los derechos y las contribuciones de todas las personas, independientemente su raza, etnia, casta, color, edad, características físicas, neurodiversidad, discapacidad, sexo o género, identidad o expresión de género, orientación sexual, idioma, filosofía o religión, origen nacional o social, posición socioeconómica, nivel de educación u otras condiciones. Los mismos privilegios se extienden a todas las personas que participen de buena fe y de acuerdo con este Convenio.
+
+## Conducta esperada
+
+Reconociendo las diferencias en las normas sociales, todos nosotros buscamos cumplir con las expectativas de buena conducta de nuestra comunidad. También entendemos que nuestras palabras y acciones pueden interpretarse de manera diferente a lo que queremos transmitir, debido a factores como la cultura, el contexto o el idioma nativo.
+
+Con estas consideraciones en mente, acordamos respetarnos mutuamente y actuar de formas que reflejen nuestros valores compartidos, incluyendo:
+
+1. **Respetar el propósito de nuestra comunidad**, nuestras actividades y las formas en las que interactuamos.
+2. Involucrarse de manera **honesta y amable** con los demás.
+3. Respetar los **diferentes puntos de vista** y experiencias.
+4. **Tomar responsabilidad** de nuestras acciones y contribuciones.
+5. Dar y recibir **crítica constructiva** de manera respetuosa.
+6. **Reparar el daño** cuando ocurra.
+7. Comportarse de cualquier otra manera que promueva y mantenga **el bienestar de nuestra comunidad**.
+
+## Comportamientos no permitidos
+
+Acordamos restringir los siguientes comportamientos en nuestra comunidad. Las instancias, amenazas y promoción de estos comportamientos constituyen una violación a este Código de Conducta.
+
+1. **Acoso.** Violar los límites explicitamente establecidos por otra persona o continuar con contacto personal no deseado después de cualquier solicitud clara para detenerse.
+2. **Ataques personales.** Hacer comentarios insultantes, denigrantes o despectivos sobre alguien de la comunidad o a un grupo de personas.
+3. **Estereotipos o discriminación.** Catalogar o asumir la personalidad o el comportamiento de alguien con base en su identidad o rasgos inmutables.
+4. **Sexualización.** Comportarse de cualquier manera que generalmente se considere íntimamente inapropiada en el contexto o propósito de la comunidad.
+5. **Violación de la confidencialidad.** Compartir o hacer uso de información personal o privada de alguien sin su consentimiento.
+6. **Poner en peligro.** Causar, incitar o amenazar con violencia u otro tipo de daño hacia cualquier persona o grupo.
+7. Comportarse de cualquier otra manera que **amenace el bienestar** de nuestra comunidad.
+
+
+
+### Otras restricciones
+
+1. **Identidad engañosa.** Hacerse pasar por otra persona por cualquier razón, o fingir ser alguien más para evadir acciones disciplinarias.
+2. **Falta de atribución.** No acreditar correctamente las fuentes del contenido que se contribuye.
+3. **Material promocional.** Compartir contenido de marketing u otro contenido comercial de una manera que esté fuera de las normas de la comunidad.
+4. **Comunicación irresponsable.** No presentar de manera responsable contenido que incluya, enlace o describa cualquier otro comportamiento restringido.
+
+
+## Reportar un incidente
+
+Pueden surgir tensiones entre miembros de la comunidad incluso cuando todos hacen su mejor esfuerzo por colaborar. No todo conflicto representa una violación al código de conducta. Este Código refuerza conductas y normas que pueden ayudar a prevenirlos y minimizar el daño.
+
+Cuando ocurra un incidente, es importante reportarlo a la brevedad. Para reportar una posible violación, [NOTA: describa de qué manera se puede reportar aquí.]
+
+Las personas moderadoras toman los reportes de violaciones con seriedad y harán su mejor esfuerzo por responder oportunamente. Se investigarán todos los reportes, revisando mensajes, registros y grabaciones, o entrevistando a testigos y demás participantes. El equipo moderador mantendrán las investigaciones y acciones lo más transparentes posible, priorizando siempre la seguridad y la confidencialidad. Para respetar estos valores, las acciones se llevan a cabo de manera privada con las partes involucradas, aunque comunicarlo a toda la comunidad puede ser parte de una resolución acordada por ambas partes.
+
+## Atender y reparar el daño
+
+[NOTA: Las medidas y reparaciones descritas a continuación son sugerencias basadas en buenas prácticas para seguir nuestros códigos de conducta. Si tu comunidad tiene su propio proceso establecido, edita esta sección para describir tus propias políticas.]
+
+Si la investigación del equipo moderador determina que este Código de Conducta ha sido infringido, se puede aplicar la siguiente escala de acciones para determinar la mejor manera de reparar el daño, según el impacto del incidente en las personas involucradas y en la comunidad en general. Dependiendo de la gravedad de la violación, algunos pasos pueden omitirse.
+
+1. **Advertencia**
+   - **Situación:** Una violación que involucra un incidente único o una serie de incidentes.
+   - **Consecuencia:** Una advertencia privada y por escrito del equipo moderador.
+   - **Reparación:** Ejemplos de reparación incluyen una disculpa privada por escrito, el reconocimiento de la responsabilidad y la aclaración sobre las expectativas.
+
+2. **Restricción temporal de actividades**
+   - **Situación:** Una violación repetida que previamente resultó en una advertencia, o la primera ocurrencia de una violación seria.
+   - **Consecuencia:** Una advertencia privada por escrito con un período de pausa temporal, diseñado para subrayar la seriedad de la situación y dar tiempo a las personas involucradas para procesar el incidente. Este período puede limitarse a ciertos canales de comunicación o interacciones con miembros específicos de la comunidad.
+   - **Reparación:** Ejemplos de reparación incluyen ofrecer una disculpa, usar el período de pausa para reflexionar sobre sus acciones y su impacto, y ser consciente al reintegrarse a los espacios de la comunidad.
+
+3. **Suspensión temporal**
+   - **Situación:** Un patrón de violaciones repetidas que el equipo moderador ha intentado abordar con advertencias, o una violación grave única.
+   - **Consecuencia:** Una advertencia privada por escrito con condiciones para el regreso. En general, las suspensiones temporales dan a la persona suspendida tiempo para reflexionar sobre su comportamiento y las posibles acciones correctivas.
+   - **Reparación:** Ejemplos de reparación incluyen respetar el espíritu de la suspensión, cumplir con las condiciones establecidas para el regreso y reflexionar sobre cómo reintegrarse a la comunidad al levantarse la suspensión.
+4. **Expulsión permanente**
+   - **Situación:** Un patrón de violaciones repetidas que los pasos anteriores no han logrado resolver, o una violación tan grave que el equipo moderador determina que no es posible mantener la seguridad de la comunidad con esa persona como miembro.
+   - **Consecuencia:** Se revoca el acceso a todos los espacios, herramientas y canales de comunicación de la comunidad. Las expulsiones permanentes deben usarse raramente, estar bien fundamentadas y ser el último recurso cuando otras medidas han fallado.
+   - **Reparación:** No existe reparación posible en casos de esta gravedad.
+
+Esta escala de acciones es solo una guía. No limita la capacidad del equipo moderador de usar su criterio y juicio en beneficio de nuestra comunidad.
+
+## Alcance
+
+Este Código de Conducta aplica en todos los espacios de la comunidad, y también cuando una persona representa oficialmente a la comunidad en espacios públicos o externos. Algunos ejemplos incluyen usar una dirección de correo oficial, publicar desde una cuenta oficial en redes sociales, o actuar como representante designada o designado en un evento presencial o en línea.
+
+## Atribución
+
+Este Código de Conducta está adaptado del Contributor Covenant, versión 3.0, disponible de manera permanentemente en [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
+
+Contributor Covenant es administrado por la Organización para el Código Ético, bajo la licencia CC BY-SA 4.0. Para ver una copia de esta licencia, visita [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/).
+
+Para ver las respuestas a preguntas frecuentes sobre Contributor Covenant, ver [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Las traducciones están disponibles en [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Recursos adicionales sobre moderación y guías comunitarias pueden encontrarse en [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources). La escala de acciones fue inspirada por el trabajo del [equipo de código de conducta de Mozilla](https://github.com/mozilla/inclusion).


### PR DESCRIPTION
Hi! 

I'm working on a EN/ES project and included your Code of Conduct version 3.0 in English. Since the Spanish translation is only available for version 2.1, I translated the latest version to make both languages consistent. 

Happy to adjust anything if needed!
