### PR TITLE
Add Uzbek translation of Code of Conduct

### DIFF
--- a/content/version/1/3/0/code-of-conduct.uz.md
+++ b/content/version/1/3/0/code-of-conduct.uz.md
@@ -1,0 +1,31 @@
++++
+version = "1.3"
+aliases = ["/version/1/3/0/uz"]
++++
+
+# Ishtirokchilarning odob-ahloq kodeksi
+
+Ushbu loyihaning ishtirokchilari va ma'murlari sifatida hamda ochiq va mehmondo'st hamjamiyatni shakllantirish maqsadida, biz muammolar haqida xabar berish, funksional so'rovlarni yuborish, hujjatlarni yangilash, pull request yoki patch-larni taqdim etish va boshqa faoliyatlar orqali hissa qo'shadigan barcha insonlarni hurmat qilishga va'da beramiz.
+
+Biz tajriba darajasi, jinsi, gender identifikatsiyasi va ifodasi, jinsiy orientatsiyasi, nogironligi, tashqi ko'rinishi, tana tuzilishi, irqi, etnik kelib chiqishi, yoshi, dini yoki millatidan qat'i nazar, ushbu loyihadagi ishtirokni barcha uchun tazyiqlardan xoli bo'lishini ta'minlash majburiyatini olamiz.
+
+Ishtirokchilar tomonidan sodir etilishi mumkin bo'lgan nomaqbul xatti-harakatlarga misollar:
+
+* Shahvoniy til yoki tasvirlardan foydalanish
+* Shaxsiy hujumlar (shaxsiyatga tegish)
+* Trolling yoki haqoratli/kamsituvchi sharhlar
+* Ommaviy yoki shaxsiy tazyiqlar
+* Boshqa shaxslarning ruxsatisiz ularning shaxsiy ma'lumotlarini (masalan, yashash yoki elektron pochta manzillari) nashr etish/ulashish
+* Boshqa axloqsiz yoki noproprofessional xatti-harakatlar
+
+Loyiha ma'murlari ushbu Odob-ahloq kodeksiga mos kelmaydigan sharhlar, commit-lar, kodlar, viki tahrirlari, issue-lar va boshqa hissalarni o'chirish, tahrirlash yoki rad etish huquqiga va majburiyatiga ega, shuningdek, boshqa har qanday nomaqbul, tahdidli, haqoratli yoki zararli deb hisoblagan xatti-harakatlari uchun har qanday ishtirokchini vaqtincha yoki butunlay chetlashtirish huquqiga egadirlar.
+
+Ushbu Odob-ahloq kodeksini qabul qilish orqali loyiha ma'murlari ushbu tamoyillarni ushbu loyihani boshqarishning har bir jabhasida adolatli va izchil qo'llash majburiyatini oladilar. Odob-ahloq kodeksiga rioya qilmaydigan yoki uni tatbiq etmaydigan loyiha ma'murlari loyiha jamoasidan butunlay chetlashtirilishi mumkin.
+
+Ushbu Odob-ahloq kodeksi loyiha maydonlarida hamda shaxs loyiha yoki uning hamjamiyati nomidan vakillik qilayotgan jamoat joylarida ham amal qiladi.
+
+Haqoratli, tazyiq o'tkazuvchi yoki boshqa nomaqbul xatti-harakatlar holatlari haqida loyiha ma'muriga [EMAIL MANZILINI KIRITING] orqali xabar berilishi mumkin. Barcha shikoyatlar ko'rib chiqiladi va tekshiriladi hamda vaziyatga qarab zarur va tegishli deb hisoblangan choralar ko'riladi. Ma'murlar voqea haqida xabar bergan shaxsning maxfiyligini saqlashga majburdirlar.
+
+Ushbu Odob-ahloq kodeksi [Contributor Covenant][homepage] ning 1.3.0 versiyasidan moslashtirilgan bo'lib, unga https://www.contributor-covenant.org/version/1/3/0/code-of-conduct.html manzili orqali kirish mumkin.
+
+[homepage]: https://www.contributor-covenant.org

--- a/content/version/1/4/code-of-conduct.uz.md
+++ b/content/version/1/4/code-of-conduct.uz.md
@@ -1,0 +1,52 @@
++++
+version = "1.4"
+aliases = ["/version/1/4/uz"]
++++
+
+# Ishtirokchilar kelishuvi odob-ahloq kodeksi
+
+## Bizning majburiyatimiz
+
+Ochiq va mehmondo'st muhitni shakllantirish maqsadida, biz ishtirokchilar va ma'murlar sifatida yoshi, tana tuzilishi, nogironligi, etnik kelib chiqishi, jinsiy belgilari, gender identifikatsiyasi va ifodasi, tajriba darajasi, ma'lumoti, ijtimoiy-iqtisodiy mavqeyi, millati, tashqi ko'rinishi, irqi, dini yoki jinsiy o'ziga xosligi (identifikatsiyasi) va orientatsiyasidan qat'i nazar, loyihamiz va hamjamiyatimizdagi ishtirokni barcha uchun tazyiqlardan xoli bo'lishini ta'minlashga va'da beramiz.
+
+## Bizning standartlarimiz
+
+Ijobiy muhit yaratishga yordam beradigan xatti-harakatlarga misollar:
+
+* Mehmondo'st va inklyuziv tildan foydalanish
+* Turli qarashlar va tajribalarni hurmat qilish
+* Konstruktiv tanqidni xushmuomalalik bilan qabul qilish
+* Hamjamiyat uchun nima eng yaxshi ekanligiga e'tibor qaratish
+* Hamjamiyatning boshqa a'zolariga nisbatan e'tiborli bo'lish
+
+Ishtirokchilar tomonidan sodir etilishi mumkin bo'lgan nomuvofiq (nomaqbul) xatti-harakatlarga misollar:
+
+* Shahvoniy til yoki tasvirlardan foydalanish hamda nomaqbul shahvoniy e'tibor yoki yaqinlik qilishga urinishlar
+* Trolling, haqoratli/kamsituvchi sharhlar va shaxsiy yoki siyosiy hujumlar (shaxsiyatga tegish)
+* Ommaviy yoki shaxsiy tazyiqlar
+* Boshqa shaxslarning ruxsatisiz ularning shaxsiy ma'lumotlarini (masalan, yashash joyi yoki elektron pochta manzili) nashr etish/ulashish
+* Professional muhitda nomuvofiq deb hisoblanishi mumkin bo'lgan boshqa xatti-harakatlar
+
+## Bizning majburiyatlarimiz
+
+Loyiha ma'murlari maqbul xatti-harakatlar standartlarini tushuntirish uchun mas'uldirlar va har qanday nomaqbul xatti-harakatlar holatlariga javoban tegishli va adolatli choralar ko'rishlari kutiladi.
+
+Loyiha ma'murlari ushbu Odob-ahloq kodeksiga mos kelmaydigan sharhlar, commit-lar, kodlar, viki tahrirlari, issue-lar va boshqa hissalarni o'chirish, tahrirlash yoki rad etish huquqiga va majburiyatiga ega, shuningdek, boshqa har qanday nomaqbul, tahdidli, haqoratli yoki zararli deb hisoblagan xatti-harakatlari uchun har qanday ishtirokchini vaqtincha yoki butunlay chetlashtirish huquqiga egadirlar.
+
+## Amal qilish sohasi
+
+Ushbu Odob-ahloq kodeksi barcha loyiha maydonlarida amal qiladi, shuningdek, shaxs jamoat joylarida loyiha yoki uning hamjamiyati nomidan rasman vakillik qilganida ham qo'llaniladi. Loyiha yoki hamjamiyat nomidan vakillik qilishga rasmiy loyiha elektron pochta manzilidan foydalanish, rasmiy ijtimoiy tarmoq hisobi orqali post joylashtirish yoki onlayn yoxud oflayn tadbirda tayinlangan vakil sifatida ishtirok etish kiradi. Loyiha nomidan vakillik qilish holatlari loyiha ma'murlari tomonidan qo'shimcha ravishda belgilanishi va tushuntirilishi mumkin.
+
+## Qoidalarni tatbiq etish
+
+Haqoratli, tazyiq o'tkazuvchi yoki boshqa nomaqbul xatti-harakatlar holatlari haqida loyiha jamoasiga [EMAIL MANZILINI KIRITING] orqali xabar berilishi mumkin. Barcha shikoyatlar ko'rib chiqiladi va tekshiriladi hamda vaziyatga qarab zarur va tegishli deb hisoblangan choralar ko'riladi. Loyiha jamoasi voqea haqida xabar bergan shaxsning maxfiyligini saqlashga majburdir. Qoidalarni tatbiq etishning aniq siyosati bo'yicha qo'shimcha tafsilotlar alohida e'lon qilinishi mumkin.
+
+Loyiha ma'murlari odob-ahloq kodeksiga rioya qilmasalar yoki uni insof bilan tatbiq etmasalar, loyiha rahbariyatining boshqa a'zolari tomonidan belgilangan vaqtincha yoki doimiy choralar (oqibatlar) bilan to'qnash kelishlari mumkin.
+
+## Mualliflik huquqi
+
+Ushbu Odob-ahloq kodeksi [Contributor Covenant][homepage] ning 1.4 versiyasidan moslashtirilgan bo'lib, unga https://www.contributor-covenant.org/version/1/4/code-of-conduct.html manzili orqali kirish mumkin.
+
+[homepage]: https://www.contributor-covenant.org
+
+Ushbu odob-ahloq kodeksi haqidagi tez-tez beriladigan savollarga javoblarni https://www.contributor-covenant.org/faq sahifasidan topishingiz mumkin.

--- a/content/version/2/0/code_of_conduct.uz.md
+++ b/content/version/2/0/code_of_conduct.uz.md
@@ -1,0 +1,89 @@
++++
+version = "2.0"
+aliases = ["/version/2/0/uz"]
+reportingPlaceholder = "[ALOQA MA'LUMOTLARINI KIRITING]"
++++
+
+# Ishtirokchilar kelishuvi odob-ahloq kodeksi
+
+## Bizning majburiyatimiz
+
+Biz a'zolar, ishtirokchilar va rahbarlar sifatida yoshi, tana tuzilishi, ko'rinadigan yoki ko'rinmas nogironligi, etnik kelib chiqishi, jinsiy belgilari, gender identifikatsiyasi va ifodasi, tajriba darajasi, ma'lumoti, ijtimoiy-iqtisodiy mavqeyi, millati, tashqi ko'rinishi, irqi, dini yoki jinsiy o'ziga xosligi (identifikatsiyasi) va orientatsiyasidan qat'i nazar, hamjamiyatimizdagi ishtirokni barcha uchun tazyiq va kamsitishlardan xoli bo'lishini ta'minlashga va'da beramiz.
+
+Biz ochiq, mehmondo'st, ko'p qirrali, inklyuziv va sog'lom hamjamiyatni shakllantirishga hissa qo'shadigan tarzda harakat qilishga va muloqot qilishga va'da beramiz.
+
+## Bizning standartlarimiz
+
+Hamjamiyatimiz uchun ijobiy muhit yaratishga yordam beradigan xatti-harakatlarga misollar:
+
+* Boshqa odamlarga nisbatan e'tiborli bo'lish va mehribonlik ko'rsatish
+* Turli fikrlar, qarashlar va tajribalarni hurmat qilish
+* Konstruktiv fikr-mulohazalarni bildirish va xushmuomalalik bilan qabul qilish
+* Xatolarimizdan jabr ko'rganlar uchun mas'uliyatni o'z zimmamizga olish va uzr so'rash hamda ushbu tajribadan saboq olish
+* Shaxsan o'zimiz uchun emas, balki butun hamjamiyat uchun nima eng yaxshi ekanligiga e'tibor qaratish
+
+Nomuvofiq (nomaqbul) xatti-harakatlarga misollar:
+
+* Shahvoniy til yoki tasvirlardan foydalanish hamda har qanday shakldagi shahvoniy e'tibor yoki yaqinlik qilishga urinishlar
+* Trolling, haqoratli yoki kamsituvchi sharhlar hamda shaxsiy yoki siyosiy hujumlar (shaxsiyatga tegish)
+* Ommaviy yoki shaxsiy tazyiqlar
+* Boshqa shaxslarning ruxsatisiz ularning shaxsiy ma'lumotlarini (masalan, yashash yoki elektron pochta manzili) nashr etish/ulashish
+* Professional muhitda nomuvofiq deb hisoblanishi mumkin bo'lgan boshqa xatti-harakatlar
+
+## Nazorat qilish mas'uliyati
+
+Hamjamiyat rahbarlari maqbul xulq-atvor standartlarimizni tushuntirish va ularga rioya etilishini nazorat qilish uchun mas'uldirlar. Ular har qanday nomaqbul, tahdidli, haqoratli yoki zararli deb hisoblagan xatti-harakatlarga javoban tegishli va adolatli choralar ko'radilar.
+
+Hamjamiyat rahbarlari ushbu Odob-ahloq kodeksiga mos kelmaydigan sharhlar, commit-lar, kodlar, viki tahrirlari, issue-lar va boshqa hissalarni o'chirish, tahrirlash yoki rad etish huquqi hamda majburiyatiga ega va zarur hollarda moderatsiya qarorlarining sabablarini ma'lum qiladilar.
+
+## Amal qilish sohasi
+
+Ushbu Odob-ahloq kodeksi barcha hamjamiyat maydonlarida amal qiladi, shuningdek, shaxs jamoat joylarida hamjamiyat nomidan rasman vakillik qilganida ham qo'llaniladi. Hamjamiyatimiz nomidan vakillik qilishga rasmiy elektron pochta manzilidan foydasanish, rasmiy ijtimoiy tarmoq hisobi orqali post joylashtirish yoki onlayn yoxud oflayn tadbirda tayinlangan vakil sifatida ishtirok etish kiradi.
+
+## Qoidalarni tatbiq etish
+
+Haqoratli, tazyiq o'tkazuvchi yoki boshqa nomaqbul xatti-harakatlar holatlari haqida qoidalarni tatbiq etish uchun mas'ul bo'lgan hamjamiyat rahbarlariga [ALOQA MA'LUMOTLARINI KIRITING] orqali xabar berilishi mumkin. Barcha shikoyatlar zudlik bilan va xolisona ko'rib chiqiladi hamda tekshiriladi.
+
+Barcha hamjamiyat rahbarlari har qanday voqea haqida xabar bergan shaxsning maxfiyligi va xavfsizligini hurmat qilishga majburdirlar.
+
+## Tartib-qoidalar bo'yicha ko'rsatmalar
+
+Hamjamiyat rahbarlari ushbu Odob-ahloq kodeksini buzgan deb topilgan har qanday harakatning oqibatlarini aniqlashda quyidagi Hamjamiyatga ta'sir ko'rsatmalari (Community Impact Guidelines) asosida ish tutadilar:
+
+### 1. Tuzatish
+
+**Hamjamiyatga ta'siri**: Nomaqbul tildan foydalanish yoki hamjamiyatda noproprofessional yoxud nomaqbul deb hisoblangan boshqa xatti-harakatlar.
+
+**Oqibat**: Hamjamiyat rahbarlaridan shaxsiy, yozma ogohlantirish bo'lib, unda qoidabuzarlik tabiati aniqlashtiriladi va nima uchun bu xatti-harakat nomuvofiq bo'lganligi tushuntiriladi. Ommaviy ravishda uzr so'rash talab qilinishi mumkin.
+
+### 2. Ogohlantirish
+
+**Hamjamiyatga ta'siri**: Bitta hodisa yoki bir qator harakatlar natijasida sodir etilgan qoidabuzarlik.
+
+**Oqibat**: Nomuvofiq xatti-harakatlar davom etgan taqdirda qo'llaniladigan choralar ko'rsatilgan ogohlantirish. Ma'lum bir muddat davomida jalb qilingan shaxslar bilan har qanday muloqot qilish, jumladan Odob-ahloq kodeksining bajarilishini ta'minlovchilar bilan so'ralmagan muloqotga kirishish taqiqlanadi. Bunga hamjamiyat maydonlaridagi, shuningdek, ijtimoiy tarmoqlar kabi tashqi kanallardagi muloqotdan qochish kiradi. Ushbu shartlarni buzish vaqtincha yoki butunlay chetlashtirishga olib kelishi mumkin.
+
+### 3. Vaqtincha chetlashtirish
+
+**Hamjamiyatga ta'siri**: Hamjamiyat standartlarini jiddiy ravishda buzish, jumladan, nomaqbul xatti-harakatlarning davom etishi.
+
+**Oqibat**: Belgilangan muddat davomida hamjamiyat bilan har qanday o'zaro aloqa yoki ommaviy muloqotdan vaqtincha chetlashtirish. Ushalanayotgan davrda jalb qilingan shaxslar bilan ommaviy yoki shaxsiy muloqot qilish, jumladan Odob-ahloq kodeksining bajarilishini ta'minlovchilar bilan muloqotga kirishish taqiqlanadi. Ushbu shartlarni buzish oqibatida butunlay chetlashtirishga olib kelishi mumkin.
+
+### 4. Butunlay chetlashtirish
+
+**Hamjamiyatga ta'siri**: Hamjamiyat standartlarini tizimli ravishda buzish, jumladan, davomli nomaqbul xulq-atvor, alohida shaxsga nisbatan tazyiq o'tkazish yoki ma'lum bir toifadagi shaxslarga nisbatan tajovuzkorlik yoxud kamsitish ko'rsatish.
+
+**Oqibat**: Hamjamiyat doirasidagi har qanday ommaviy muloqotdan butunlay chetlashtirish.
+
+## Mualliflik huquqi
+
+Ushbu Odob-ahloq kodeksi [Contributor Covenant][homepage] ning 2.0 versiyasidan moslashtirilgan bo'lib, unga [https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0] manzili orqali kirish mumkin.
+
+Hamjamiyatga ta'sir ko'rsatmalari (Community Impact Guidelines) [Mozilla odob-ahloq kodeksi jamoasi][Mozilla CoC] ishidan ilhomlangan holda yaratilgan.
+
+Ushbu odob-ahloq kodeksi haqidagi tez-tez beriladigan savollarga javoblarni [https://www.contributor-covenant.org/faq][FAQ] sahifasidan topishingiz mumkin. Tarjimalar [https://www.contributor-covenant.org/translations][translations] sahifasida taqdim etilgan.
+
+[homepage]: https://www.contributor-covenant.org
+[v2.0]: https://www.contributor-covenant.org/version/2/0/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/content/version/2/1/code_of_conduct.uz.md
+++ b/content/version/2/1/code_of_conduct.uz.md
@@ -1,0 +1,89 @@
++++
+version = "2.1"
+aliases = ["/version/2/1/uz"]
+reportingPlaceholder = "[ALOQA MA'LUMOTLARINI KIRITING]"
++++
+
+# Ishtirokchilar kelishuvi odob-ahloq kodeksi
+
+## Bizning majburiyatimiz
+
+Biz a'zolar, ishtirokchilar va rahbarlar sifatida yoshi, tana tuzilishi, ko'rinadigan yoki ko'rinmas nogironligi, etnik kelib chiqishi, jinsiy belgilari, gender identifikatsiyasi va ifodasi, tajriba darajasi, ma'lumoti, ijtimoiy-iqtisodiy mavqeyi, millati, tashqi ko'rinishi, irqi, kastasi, terisining rangi, dini yoki jinsiy o'ziga xosligi (identifikatsiyasi) va orientatsiyasidan qat'i nazar, hamjamiyatimizdagi ishtirokni barcha uchun tazyiq va kamsitishlardan xoli bo'lishini ta'minlashga va'da beramiz.
+
+Biz ochiq, mehmondo'st, ko'p qirrali, inklyuziv va sog'lom hamjamiyatni shakllantirishga hissa qo'shadigan tarzda harakat qilishga va muloqot qilishga va'da beramiz.
+
+## Bizning standartlarimiz
+
+Hamjamiyatimiz uchun ijobiy muhit yaratishga yordam beradigan xatti-harakatlarga misollar:
+
+* Boshqa odamlarga nisbatan e'tiborli bo'lish va mehribonlik ko'rsatish
+* Turli fikrlar, qarashlar va tajribalarni hurmat qilish
+* Konstruktiv fikr-mulohazalarni bildirish va xushmuomalalik bilan qabul qilish
+* Xatolarimizdan jabr ko'rganlar uchun mas'uliyatni o'z zimmamizga olish va uzr so'rash hamda ushbu tajribadan saboq olish
+* Shaxsan o'zimiz uchun emas, balki butun hamjamiyat uchun nima eng yaxshi ekanligiga e'tibor qaratish
+
+Nomuvofiq (nomaqbul) xatti-harakatlarga misollar:
+
+* Shahvoniy til yoki tasvirlardan foydasanish hamda har qanday shakldagi shahvoniy e'tibor yoki yaqinlik qilishga urinishlar
+* Trolling, haqoratli yoki kamsituvchi sharhlar hamda shaxsiy yoki siyosiy hujumlar (shaxsiyatga tegish)
+* Ommaviy yoki shaxsiy tazyiqlar
+* Boshqa shaxslarning ruxsatisiz ularning shaxsiy ma'lumotlarini (masalan, yashash yoki elektron pochta manzili) nashr etish/ulashish
+* Professional muhitda nomuvofiq deb hisoblanishi mumkin bo'lgan boshqa xatti-harakatlar
+
+## Nazorat qilish mas'uliyati
+
+Hamjamiyat rahbarlari maqbul xulq-atvor standartlarimizni tushuntirish va ularga rioya etilishini nazorat qilish uchun mas'uldirlar. Ular har qanday nomaqbul, tahdidli, haqoratli yoki zararli deb hisoblagan xatti-harakatlarga javoban tegishli va adolatli choralar ko'radilar.
+
+Hamjamiyat rahbarlari ushbu Odob-ahloq kodeksiga mos kelmaydigan sharhlar, commit-lar, kodlar, viki tahrirlari, issue-lar va boshqa hissalarni o'chirish, tahrirlash yoki rad etish huquqi hamda majburiyatiga ega va zarur hollarda moderatsiya qarorlarining sabablarini ma'lum qiladilar.
+
+## Amal qilish sohasi
+
+Ushbu Odob-ahloq kodeksi barcha hamjamiyat maydonlarida amal qiladi, shuningdek, shaxs jamoat joylarida hamjamiyat nomidan rasman vakillik qilganida ham qo'llaniladi. Hamjamiyatimiz nomidan vakillik qilishga rasmiy elektron pochta manzilidan foydalanish, rasmiy ijtimoiy tarmoq hisobi orqali post joylashtirish yoki onlayn yoxud oflayn tadbirda tayinlangan vakil sifatida ishtirok etish kiradi.
+
+## Qoidalarni tatbiq etish
+
+Haqoratli, tazyiq o'tkazuvchi yoki boshqa nomaqbul xatti-harakatlar holatlari haqida qoidalarni tatbiq etish uchun mas'ul bo'lgan hamjamiyat rahbarlariga [ALOQA MA'LUMOTLARINI KIRITING] orqali xabar berilishi mumkin. Barcha shikoyatlar zudlik bilan va xolisona ko'rib chiqiladi hamda tekshiriladi.
+
+Barcha hamjamiyat rahbarlari har qanday voqea haqida xabar bergan shaxsning maxfiyligi va xavfsizligini hurmat qilishga majburdirlar.
+
+## Tartib-qoidalar bo'yicha ko'rsatmalar
+
+Hamjamiyat rahbarlari ushbu Odob-ahloq kodeksini buzgan deb topilgan har qanday harakatning oqibatlarini aniqlashda quyidagi Hamjamiyatga ta'sir ko'rsatmalari (Community Impact Guidelines) asosida ish tutadilar:
+
+### 1. Tuzatish
+
+**Hamjamiyatga ta'siri**: Nomaqbul tildan foydalanish yoki hamjamiyatda noproprofessional yoxud nomaqbul deb hisoblangan boshqa xatti-harakatlar.
+
+**Oqibat**: Hamjamiyat rahbarlaridan shaxsiy, yozma ogohlantirish bo'lib, unda qoidabuzarlik tabiati aniqlashtiriladi va nima uchun bu xatti-harakat nomuvofiq bo'lganligi tushuntiriladi. Ommaviy ravishda uzr so'rash talab qilinishi mumkin.
+
+### 2. Ogohlantirish
+
+**Hamjamiyatga ta'siri**: Bitta hodisa yoki bir qator harakatlar natijasida sodir etilgan qoidabuzarlik.
+
+**Oqibat**: Nomuvofiq xatti-harakatlar davom etgan taqdirda qo'llaniladigan choralar ko'rsatilgan ogohlantirish. Ma'lum bir muddat davomida jalb qilingan shaxslar bilan har qanday muloqot qilish, jumladan Odob-ahloq kodeksining bajarilishini ta'minlovchilar bilan so'ralmagan muloqotga kirishish taqiqlanadi. Bunga hamjamiyat maydonlaridagi, shuningdek, ijtimoiy tarmoqlar kabi tashqi kanallardagi muloqotdan qochish kiradi. Ushbu shartlarni buzish vaqtincha yoki butunlay chetlashtirishga olib kelishi mumkin.
+
+### 3. Vaqtincha chetlashtirish
+
+**Hamjamiyatga ta'siri**: Hamjamiyat standartlarini jiddiy ravishda buzish, jumladan, nomaqbul xatti-harakatlarning davom etishi.
+
+**Oqibat**: Belgilangan muddat davomida hamjamiyat bilan har qanday o'zaro aloqa yoki ommaviy muloqotdan vaqtincha chetlashtirish. Ushbu davrda jalb qilingan shaxslar bilan ommaviy yoki shaxsiy muloqot qilish, jumladan Odob-ahloq kodeksining bajarilishini ta'minlovchilar bilan muloqotga kirishish taqiqlanadi. Ushbu shartlarni buzish butunlay chetlashtirishga olib kelishi mumkin.
+
+### 4. Butunlay chetlashtirish
+
+**Hamjamiyatga ta'siri**: Hamjamiyat standartlarini tizimli ravishda buzish, jumladan, davomli nomaqbul xulq-atvor, alohida shaxsga nisbatan tazyiq o'tkazish yoki ma'lum bir toifadagi shaxslarga nisbatan tajovuzkorlik yoxud kamsitish ko'rsatish.
+
+**Oqibat**: Hamjamiyat doirasidagi har qanday ommaviy muloqotdan butunlay chetlashtirish.
+
+## Mualliflik huquqi
+
+Ushbu Odob-ahloq kodeksi [Contributor Covenant][homepage] ning 2.1 versiyasidan moslashtirilgan bo'lib, unga [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1] manzili orqali kirish mumkin.
+
+Hamjamiyatga ta'sir ko'rsatmalari (Community Impact Guidelines) [Mozilla odob-ahloq kodeksi jamoasi][Mozilla CoC] ishidan ilhomlangan holda yaratilgan.
+
+Ushbu odob-ahloq kodeksi haqidagi tez-tez beriladigan savollarga javoblarni [https://www.contributor-covenant.org/faq][FAQ] sahifasidan topishingiz mumkin. Tarjimalar [https://www.contributor-covenant.org/translations][translations] sahifasida taqdim etilgan.
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/content/version/3/0/code_of_conduct.uz.md
+++ b/content/version/3/0/code_of_conduct.uz.md
@@ -1,0 +1,99 @@
++++
+title = "Ishtirokchilar kelishuvi 3"
+version = "3.0"
+aliases = ["/version/3/0/uz"]
+reportingPlaceholder = "[ESLATMA: bu yerda qoidabuzarlik haqida xabar berish usulini tasvirlang.]"
+enforcementPlaceholder = "[ESLATMA: quyida keltirilgan choralar va zararni qoplash usullari odob-ahloq qoidalarini qo'llashdagi eng yaxshi tajribalarga asoslangan tavsiyalardir. Agar hamjamiyatingizda qoidabuzarliklarga munosabat bildirish bo'yicha o'z tartibingiz mavjud bo'lsa, ushbu bo'limni o'z qoidalaringizga muvofiq tahrirlang.]"
++++
+
+# Ishtirokchilar kelishuvi 3.0 odob-ahloq kodeksi
+
+## Bizning majburiyatimiz
+
+Biz hamjamiyatimizni barcha uchun mehmondo'st, xavfsiz va adolatli qilish majburiyatini olamiz.
+
+Biz irqi, etnik kelib chiqishi, kastasi, terisining rangi, yoshi, jismoniy xususiyatlari, neyroxilma-xilligi, nogironligi, jinsi yoki genderi, gender identifikatsiyasi yoki ifodasi, jinsiy orientatsiyasi, tili, dunyoqarashi yoki dini, milliy yoki ijtimoiy kelib chiqishi, ijtimoiy-iqtisodiy mavqeyi, ma'lumot darajasi yoki boshqa maqomidan qat'i nazar, barcha shaxslarning qadr-qimmati, huquqlari va hissalarini hurmat qiladigan va qo'llab-quvvatlaydigan muhitni shakllantirishga intilamiz. Insof bilan va ushbu Kelishuvga muvofiq ishtirok etadigan har bir kishiga teng ishtirok etish imkoniyati taqdim etiladi.
+
+
+## Rag'batlantiriladigan xatti-harakatlar
+
+Ijtimoiy me'yorlardagi farqlarni tan olgan holda, barchamiz hamjamiyatimizning ijobiy xulq-atvorga bo'lgan umidlarini qondirishga intilamiz. Shuningdek, madaniyatimiz, kelib chiqishimiz yoki ona tilimiz tufayli so'zlarimiz va harakatlarimiz biz nazarda tutganimizdan boshqacha talqin qilinishi mumkinligini tushunamiz.
+
+Ushbu mulohazalarni inobatga olgan holda, biz bir-birimizga nisbatan e'tiborli bo'lishga va umumiy qadriyatlarimizni markazga qo'yadigan tarzda harakat qilishga kelishib olamiz, jumladan:
+
+1. **Hamjamiyatimiz maqsadini**, faoliyatimizni va yig'ilish usullarimizni hurmat qilish.
+2. Boshqalar bilan **samimiy va halol** muloqot qilish.
+3. **Turli xil qarashlar** va tajribalarni hurmat qilish.
+4. O'z harakatlarimiz va qo'shgan hissalarimiz uchun **mas'uliyatni o'z zimmamizga olish**.
+5. **Konstruktiv fikr-mulohazalarni** xushmuomalalik bilan bildirish va qabul qilish.
+6. Zarar yetkazilganda, uni **bartaraf etish** majburiyatini olish.
+7. Hamjamiyatimizning **farovonligini** qo'llab-quvvatlaydigan va saqlab qoladigan boshqa usullarda harakat qilish.
+
+
+## Cheklangan xatti-harakatlar
+
+Biz hamjamiyatimizda quyidagi xatti-harakatlarni cheklashga kelishib olamiz. Bunday xatti-harakatlarning holatlari, tahdidlari va ularni targ'ib qilish ushbu Odob-ahloq kodeksining buzilishi hisoblanadi.
+
+1. **Tazyiq (shilqimlik).** To'xtatish haqidagi aniq so'rovdan keyin ham aniq belgilangan chegaralarni buzish yoki keraksiz shaxsiy e'tibor qaratish.
+2. **Shaxsiyatga tegish (shaxsiy hujumlar).** Hamjamiyat a'zosi yoki bir guruh odamlarga qaratilgan haqoratli, kamsituvchi yoki tahqirlovchi fikrlar bildirish.
+3. **Stereotiplash yoki kamsitish.** Kimningdir shaxsiyati yoki xulq-atvorini o'zgarmas o'ziga xosliklari yoki belgilari asosida tavsiflash.
+4. **Jinsiylashtirish (seksualizatsiya).** Hamjamiyat sharoitida yoki maqsadlarida odatda nomuvofiq yaqinlik deb hisoblanadigan tarzda harakat qilish.
+5. **Maxfiylikni buzish.** Boshqa odamning ruxsatisiz uning shaxsiy yoki maxfiy ma'lumotlarini ulashish yoki ulardan foydalanish.
+6. **Xavf ostiga qo'yish.** Har qanday shaxs yoki guruhga nisbatan zo'ravonlik yoki boshqa zarar yetkazish, shunga undash yoki tahdid qilish.
+7. Hamjamiyatimiz **farovonligiga tahdid soladigan** boshqa usullarda harakat qilish.
+
+### Boshqa cheklovlar
+
+1. **Soxta identifikatsiya.** Har qanday sababga ko'ra o'zini boshqa shaxs sifatida ko'rsatish yoki jazo choralaridan qochish uchun boshqa odam bo'lib ko'rinish.
+2. **Manbalarni ko'rsatmaslik.** Siz taqdim etgan kontent manbalarini to'g'ri ko'rsatmaslik.
+3. **Reklama materiallari.** Marketing yoki boshqa tijoriy kontentni hamjamiyat me'yorlariga to'g'ri kelmaydigan tarzda ulashish.
+4. **Mas'uliyatsiz muloqot.** Boshqa cheklangan xatti-harakatlarni o'z ichiga olgan, ularga havolalar beruvchi yoki ularni tavsiflovchi kontentni mas'uliyatsiz tarzda taqdim etish.
+
+
+## Muammo haqida xabar berish
+
+Hamjamiyat a'zolari hamkorlik qilish uchun qo'llaridan kelganicha harakat qilsalar ham, ular o'rtasida kelishmovchiliklar yuzaga kelishi mumkin. Har qanday ziddiyat ham odob-ahloq kodeksining buzilishini anglatmaydi va ushbu Odob-ahloq kodeksi mojarolarni oldini olishga va zararni kamaytirishga yordam beradigan rag'batlantiriladigan xatti-harakatlar va me'yorlarni kuchaytiradi.
+
+Biror voqea sodir bo'lganda, bu haqda zudlik bilan xabar berish muhimdir. Mumkin bo'lgan qoidabuzarlik haqida xabar berish uchun: **[ESLATMA: bu yerda xabar berish usulini tasvirlang.]**
+
+Hamjamiyat moderatorlari qoidabuzarliklar haqidagi xabarlarga jiddiy yondashadilar va o'z vaqtida javob berish uchun barcha choralarni ko'radilar. Ular odob-ahloq kodeksi buzilishi to'g'risidagi barcha xabarlarni tekshiradilar, xabarlar, loglar va yozuvlarni ko'rib chiqadilar yoki guvohlar va boshqa ishtirokchilar bilan suhbatlashadilar. Hamjamiyat moderatorlari xavfsizlik va maxfiylikni birinchi o'ringa qo'ygan holda, tergov va jazo choralarini imkon qadar shaffof saqlaydilar. Ushbu qadriyatlarni hurmat qilish maqsadida, jazo choralari jalb qilingan tomonlar bilan maxfiy tarzda amalga oshiriladi, biroq butun hamjamiyatga muloqot qilish o'zaro kelishilgan yechimning bir qismi bo'lishi mumkin.
+
+
+## Zararni bartaraf etish va qoplash
+
+**[ESLATMA: quyida keltirilgan choralar va zararni qoplash usullari odob-ahloq qoidalarini qo'llashdagi eng yaxshi tajribalarga asoslangan tavsiyalardir. Agar hamjamiyatingizda qoidabuzarliklarga munosabat bildirish bo'yicha o'z tartibingiz mavjud bo'lsa, ushbu bo'limni o'z qoidalaringizga muvofiq tahrirlang.]**
+
+Agar hamjamiyat moderatorlari tomonidan olib borilgan tergov natijasida ushbu Odob-ahloq kodeksi buzilganligi aniqlansa, zararni qoplashning eng yaxshi usulini aniqlash uchun quyidagi jazo choralari bosqichlaridan foydalanish mumkin. Bu choralar hodisaning jalb qilingan shaxslarga va umuman hamjamiyatga ta'siriga asoslanadi. Qoidabuzarlikning og'irligiga qarab, bosqichlarning quyi darajalari o'tkazib yuborilishi mumkin.
+
+1) Ogohlantirish
+   1) Voqea: Bitta hodisa yoki bir qator hodisalarni o'z ichiga olgan qoidabuzarlik.
+   2) Oqibat: Hamjamiyat moderatorlaridan shaxsiy, yozma ogohlantirish.
+   3) Qoplash (Tuzatish): Tuzatish choralariga shaxsiy yozma uzr so'rash, mas'uliyatni tan olish va kutilayotgan xatti-harakatlar bo'yicha tushuntirish so'rash kiradi.
+2) Faoliyatni vaqtincha cheklash
+   1) Voqea: Muqaddam ogohlantirishga sabab bo'lgan qoidabuzarlikning takrorlanishi yoki jiddiyroq qoidabuzarlikning birinchi marta sodir etilishi.
+   2) Oqibat: Vaziyatning jiddiyligini ta'kidlash va jalb qilingan hamjamiyat a'zolariga sodir bo'lgan voqeani mulohaza qilish uchun vaqt berish maqsadida shaxsiy, yozma ogohlantirish va vaqt bilan cheklangan sovush (tinchlanish) davri. Tinchlanish davri faqat ma'lum aloqa kanallari yoki ma'lum hamjamiyat a'zolari bilan o'zaro munosabatlar bilan cheklanishi mumkin.
+   3) Qoplash (Tuzatish): Tuzatish choralariga uzr so'rash, tinchlanish davridan harakatlar va ularning ta'siri haqida o'ylash uchun foydalanish va bu davr tugagandan so'ng hamjamiyat maydonlariga qayta kirish haqida chuqur o'ylash kirishi mumkin.
+3) Vaqtincha chetlashtirish (to'xtatib turish)
+   1) Voqea: Hamjamiyat moderatorlari ogohlantirishlar orqali hal qilishga uringan takroriy qoidabuzarliklar zanjiri yoki bitta jiddiy qoidabuzarlik.
+   2) Oqibat: Vaqtincha chetlashtirishdan keyin qaytish shartlari ko'rsatilgan shaxsiy yozma ogohlantirish. Umuman olganda, vaqtincha chetlashtirish jazosini olgan shaxsga o'z xulq-atvori va yuzaga kelishi mumkin bo'lgan tuzatish harakatlari haqida o'ylab ko'rish uchun vaqt beradi.
+   3) Qoplash (Tuzatish): Tuzatish choralariga chetlashtirish qoidalariga rioya qilish, qaytish uchun belgilangan shartlarni bajarish va chetlashtirish muddati tugagach, hamjamiyat bilan qanday integratsiyalashish haqida chuqur o'ylash kiradi.
+4) Butunlay chetlashtirish (bloklash)
+   1) Voqea: Bosqichlarning boshqa choralari yordamida hal qilib bo'lmagan takroriy qoidabuzarliklar zanjiri yoki hamjamiyat moderatorlari ushbu shaxs a'zoligida hamjamiyat xavfsizligini ta'minlashning hech qanday iloji yo'q deb hisoblaydigan darajadagi jiddiy qoidabuzarlik.
+   2) Oqibat: Hamjamiyatning barcha maydonlari, vositalari va aloqa kanallariga kirish huquqini bekor qilish. Umuman olganda, butunlay chetlashtirish kamdan-kam hollarda, jiddiy asoslar mavjud bo'lganda va faqat boshqa choralar xulq-atvorni o'zgartira olmagan taqdirdagina oxirgi chora sifatida qo'llanilishi kerak.
+   3) Qoplash (Tuzatish): Bunday og'ir holatlarda zararni qoplashning iloji yo'q.
+
+Ushbu jazo choralari bosqichlari qo'llanma sifatida mo'ljallangan. U hamjamiyat menejerlarining o'z xohishlariga ko'ra va hamjamiyatimiz manfaatlaridan kelib chiqqan holda qaror qabul qilish imkoniyatlarini cheklamaydi.
+
+
+## Amal qilish sohasi
+
+Ushbu Odob-ahloq kodeksi barcha hamjamiyat maydonlarida amal qiladi, shuningdek, shaxs jamoat yoki boshqa joylarda hamjamiyat nomidan rasman vakillik qilganida ham qo'llaniladi. Hamjamiyatimiz nomidan vakillik qilishga rasmiy elektron pochta manzilidan foydalanish, rasmiy ijtimoiy tarmoq hisobi orqali post joylashtirish yoki onlayn yoxud oflayn tadbirda tayinlangan vakil sifatida ishtirok etish kiradi.
+
+
+## Mualliflik huquqi
+
+Ushbu Odob-ahloq kodeksi [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/) manzilida doimiy ravishda mavjud bo'lgan Ishtirokchilar kelishuvining (Contributor Covenant) 3.0 versiyasidan moslashtirildi.
+
+Ishtirokchilar kelishuvi "Organization for Ethical Source" tashkiloti tomonidan boshqariladi va CC BY-SA 4.0 litsenziyasi ostida taqdim etiladi. Ushbu litsenziyaning nusxasini ko'rish uchun [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/) sahifasiga tashrif buyuring.
+
+Ishtirokchilar kelishuvi haqidagi tez-tez beriladigan savollarga javoblarni [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq) manzilidagi FAQ sahifasidan topishingiz mumkin. Tarjimalar [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations) sahifasida taqdim etilgan. Qo'shimcha tartib-qoidalar va hamjamiyat ko'rsatmalari manbalarini [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources) manzilidan topish mumkin. Choralarni qo'llash bosqichlari [Mozilla odob-ahloq kodeksi jamoasi](https://github.com/mozilla/inclusion) ishidan ilhomlangan holda yaratilgan.

--- a/hugo.toml
+++ b/hugo.toml
@@ -210,3 +210,8 @@ languageCode = "glg"
 [Languages.vi]
 languageName = "Vietnamese"
 languageCode = "vi"
+
+[Languages.uz]
+languageName = "Oʻzbekcha"
+languageCode = "uz"
+


### PR DESCRIPTION
## Problem
The Contributor Covenant currently lacks official translations for the Uzbek language (`uz`). This PR addresses that by introducing Uzbek translations for all major versions of the Code of Conduct (v1.3.0, v1.4, v2.0, v2.1, and v3.0).

## Solution
- Added Uzbek (`uz`) language configuration to `hugo.toml` with `Oʻzbekcha` as the
language name.
- Created the following translation files based on the original English versions:
- `content/version/3/0/code_of_conduct.uz.md`
- `content/version/2/1/code_of_conduct.uz.md`
- `content/version/2/0/code_of_conduct.uz.md`
- `content/version/1/4/code-of-conduct.uz.md`
- `content/version/1/3/0/code--of-conduct.uz.md`
- Translated the texts carefully using formal and professional Uzbek terminology appropriate for official codes of conduct.

## Todo
- [x] Add Uzbek translation files for versions 1.3, 1.4, 2.0, 2.1, and 3.0.
- [x] Enable and configure the Uzbek language (`uz`) in `hugo.toml`.

## Notes for Reviewers
- The translation strictly adheres to the official Uzbek Latin alphabet rules (using the correct modifier character `ʻ` for `Oʻzbekcha`).
- All links, aliases, and front matter formatting have been updated to match the existing translations in the repository.